### PR TITLE
Add nm-vpn, battery, wifi and keyboard layout blocklet

### DIFF
--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -1,6 +1,5 @@
 # i3xrocks config file
-#
-# The man page for i3blocks is hosted at http://vivien.github.io/i3blocks
+# # The man page for i3blocks is hosted at http://vivien.github.io/i3blocks
 #
 # List of valid properties:
 #
@@ -49,9 +48,10 @@ min_width=100%
 
 # Battery indicator
 #
-# The battery instance defaults to 0.
-[battery]
-label= 
+# Displays an icon representing current charge as well as
+# a coloured percentage of battery charge remaining.
+# It also displays the estimated time left on current charge.
+[battery2]
 interval=30
 
 # Date Time

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -28,6 +28,15 @@ separator_block_width=40
 markup=pango
 color=xresource:i3xrocks.label.color
 
+# Wifi
+#
+# Displays the wifi network's name
+# If the auto-discovered wifi device is incorrect,
+# override the "instance" value with the desired device
+[wifi2]
+#instance=wlp3s0 Replace with your wifi device if you need
+interval=5
+
 # CPU usage
 #
 # The script may be called with -w and -c switches to specify thresholds,

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -27,6 +27,13 @@ separator_block_width=40
 markup=pango
 color=xresource:i3xrocks.label.color
 
+# Network manager VPN
+#
+# Displays currently connected VPN using the nm-cli tool.
+#[nm-vpn]
+#label=VPN:
+#interval=5
+
 # Wifi
 #
 # Displays the wifi network's name
@@ -35,6 +42,12 @@ color=xresource:i3xrocks.label.color
 [wifi2]
 #instance=wlp3s0 Replace with your wifi device if you need
 interval=5
+
+# Keyboard layout
+#
+# Displays current keyboard layout.
+#[keyboard_layout]
+#interval=persist
 
 # CPU usage
 #

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -48,11 +48,14 @@ min_width=100%
 
 # Battery indicator
 #
-# Displays an icon representing current charge as well as
-# a coloured percentage of battery charge remaining.
-# It also displays the estimated time left on current charge.
+# Displays total percentage charge left across all batteries.
+# Can optionally display time left with display_time_left (value doesn't matter).
+# Can also change the color of the percentage text depending on
+# charge remaining with percent_color (value doesn't matter).
 [battery2]
 interval=30
+#display_time_left=true
+percent_color=true
 
 # Date Time
 #

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -49,13 +49,18 @@ min_width=100%
 # Battery indicator
 #
 # Displays total percentage charge left across all batteries.
-# Can optionally display time left with display_time_left (value doesn't matter).
-# Can also change the color of the percentage text depending on
-# charge remaining with percent_color (value doesn't matter).
+#
+# To display colored text (or icon, if "icon_only" is enabled)
+# depending on charge remaining, uncomment "percent_color".
+#
+# To display est. time remaining, uncomment "display_time_left".
+#
+# To display the battery icon only, uncomment "icon_only".
 [battery2]
 interval=30
 #display_time_left=true
 percent_color=true
+#icon_only=true
 
 # Date Time
 #

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -25,13 +25,13 @@
 command=/usr/share/i3xrocks/$BLOCK_NAME
 separator_block_width=40
 markup=pango
-color=xresource:i3xrocks.label.color
+color=xresource:i3xrocks.value.color
+label_color=xresource:i3xrocks.label.color
 
 # Network manager VPN
 #
 # Displays currently connected VPN using the nm-cli tool.
 #[nm-vpn]
-#label=VPN:
 #interval=5
 
 # Wifi
@@ -54,7 +54,6 @@ interval=5
 # The script may be called with -w and -c switches to specify thresholds,
 # see the script for details.
 [cpu_usage]
-label= 
 interval=5
 min_width=100%
 #separator=false
@@ -78,6 +77,5 @@ percent_color=true
 # Date Time
 #
 [time]
-label=
 interval=60
 

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -14,6 +14,8 @@ import os
 status = check_output(['acpi'], universal_newlines=True)
 default_color = os.getenv('color', check_output(['/usr/bin/xrescat', 'i3xrocks.value.color'], universal_newlines=True))
 default_label_color = os.getenv('label_color', check_output(['/usr/bin/xrescat', 'i3xrocks.label.color'], universal_newlines=True))
+valuefont = os.getenv('font', check_output(['/usr/bin/xrescat', 'i3xrocks.value.font'], universal_newlines=True))
+
 
 if not status:
     print("")
@@ -115,15 +117,16 @@ else:
             shorttext = shorttext.strip()
     else:
         if os.environ.get('percent_color'):
-            form =  '<span color="{}">{}{}</span>'
-            fulltext += form.format(color(percentleft), percentleft, "%")
-            shorttext = form.format(color(percentleft), percentleft, "")
+            form =  '<span font_desc="{}" color="{}">{}{}</span>'
+            fulltext += form.format(valuefont, color(percentleft), percentleft, "%")
+            shorttext = form.format(valuefont, color(percentleft), percentleft, "")
         else:
-            form =  '<span>{}{}</span>'
-            fulltext += form.format(percentleft, "%")
-            shorttext = form.format(percentleft, "%")
+            form =  '<span font_desc="{}" >{}{}</span>'
+            fulltext += form.format(valuefont, percentleft, "%")
+            shorttext = form.format(valuefont, percentleft, "%")
         if os.environ.get('display_time_left'):
-            fulltext += timeleft
+            form =  '<span font_desc="{}">{}</span>'
+            fulltext += form.format(valuefont, timeleft)
 
 print(fulltext)
 print(shorttext)

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -12,11 +12,13 @@ from subprocess import check_output
 import os
 
 status = check_output(['acpi'], universal_newlines=True)
+default_color = os.getenv('color', check_output(['/usr/bin/xrescat', 'i3xrocks.value.color'], universal_newlines=True))
+default_label_color = os.getenv('label_color', check_output(['/usr/bin/xrescat', 'i3xrocks.label.color'], universal_newlines=True))
 
 if not status:
-    # stands for no battery found
-    fulltext = "<span color='red'><span font='FontAwesome'>\uf00d \uf240</span></span>"
-    percentleft = 100
+    print("")
+    print("")
+    exit(0)
 else:
     # if there is more than one battery in one laptop, the percentage left is 
     # available for each battery separately, although state and remaining 
@@ -45,13 +47,15 @@ else:
                 percentleft_batteries.append(p)
             commasplitstatus_batteries.append(commasplitstatus)
     state = state_batteries[0]
+    if state_batteries[0] == "Unknown":
+        state = state_batteries[1]
     commasplitstatus = commasplitstatus_batteries[0]
     if percentleft_batteries:
         percentleft = int(sum(percentleft_batteries)/len(percentleft_batteries))
     else:
         percentleft = 0
     
-    def battery_icon(percent):
+    def get_battery_icon(percent):
         if percent < 20:
             # exit code 33 will turn background red
             return "\uf244"
@@ -64,25 +68,28 @@ else:
         return "\uf240"
 
     # stands for charging
-    FA_LIGHTNING = "<span color='yellow'><span font='FontAwesome'>\uf0e7</span></span>"
+    FA_LIGHTNING = "\uf0e7"
 
     # stands for plugged in
-    FA_PLUG = "<span font='FontAwesome'>\uf1e6</span>"
+    FA_PLUG = "\uf1e6"
 
     # stands for unknown status of battery
-    FA_QUESTION = "<span font='FontAwesome'>\uf128</span>"
+    FA_QUESTION = "\uf128"
 
 
     if state == "Discharging":
-        fulltext = battery_icon(percentleft) + "   "
+        battery_icon = get_battery_icon(percentleft) + "  "
     elif state == "Full":
-        fulltext = FA_PLUG + " "
+        battery_icon = FA_PLUG + "  "
         timeleft = ""
     elif state == "Unknown":
-        fulltext = FA_QUESTION + " " + FA_BATTERY + " "
+        battery_icon = FA_QUESTION + "  " + get_battery_icon(percentleft) + "  "
         timeleft = ""
     else:
-        fulltext = FA_LIGHTNING + " " + FA_PLUG + " "
+        battery_icon = FA_LIGHTNING + " " + FA_PLUG + "  "
+
+    label_form = '<span color="{}" font="FontAwesome">{}</span>'
+    fulltext = label_form.format(default_label_color, battery_icon)
 
     def color(percent):
         if percent < 10:
@@ -94,15 +101,7 @@ else:
             return "#FF6600"
         if percent < 40:
             return "#FF9900"
-        if percent < 50:
-            return "#FFCC00"
-        if percent < 60:
-            return "#FFFF00"
-        if percent < 70:
-            return "#FFFF33"
-        if percent < 80:
-            return "#FFFF66"
-        return "#FFFFFF"
+        return default_color
 
     # make sure we use proper short vs full text even if they don't differ much
     shorttext = fulltext
@@ -125,7 +124,6 @@ else:
             shorttext = form.format(percentleft, "%")
         if os.environ.get('display_time_left'):
             fulltext += timeleft
-
 
 print(fulltext)
 print(shorttext)

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -3,7 +3,7 @@
 # Copyright (C) 2016 James Murphy
 # Licensed under the GPL version 2 only
 #
-# Modofied by Leo Palmer 2019
+# Modified by Leo Palmer 2019
 #
 # A battery indicator blocklet script for i3blocks
 
@@ -104,17 +104,31 @@ else:
             return "#FFFF66"
         return "#FFFFFF"
 
-    if os.environ.get('percent_color'):
-        form =  '<span color="{}">{}%</span>'
-        fulltext += form.format(color(percentleft), percentleft)
+    # make sure we use proper short vs full text
+    shorttext = fulltext
+    if os.environ.get('icon_only'):
+        if os.environ.get('percent_color'):
+            form = '<span color="{}">{}%</span>'
+            fulltext = form.format(color(percentleft),fulltext.strip())
+            shorttext = form.format(color(percentleft),shorttext.strip())
+        else:
+            fulltext = fulltext.strip()
+            shorttext = shorttext.strip()
+
     else:
-        form =  '<span>{}%</span>'
-        fulltext += form.format(percentleft)
-    if os.environ.get('display_time_left'):
-        fulltext += timeleft
-    
+        if os.environ.get('percent_color'):
+            form =  '<span color="{}">{}%</span>'
+            fulltext += form.format(color(percentleft), percentleft)
+            shorttext += form.format(color(percentleft), percentleft)
+        else:
+            form =  '<span>{}%</span>'
+            fulltext += form.format(percentleft)
+            shorttext += form.format(percentleft)
+        if os.environ.get('display_time_left'):
+            fulltext += timeleft
+
 
 print(fulltext)
-print(fulltext)
+print(shorttext)
 if percentleft < 10:
     exit(33)

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -50,12 +50,12 @@ else:
         percentleft = int(sum(percentleft_batteries)/len(percentleft_batteries))
     else:
         percentleft = 0
-
+    
     def battery_icon(percent):
-        if percent < 10:
+        if percent < 20:
             # exit code 33 will turn background red
             return "\uf244"
-        if percent < 25:
+        if percent < 35:
             return "\uf243"
         if percent < 50:
             return "\uf242"
@@ -74,7 +74,7 @@ else:
 
 
     if state == "Discharging":
-        fulltext = battery_icon(percentleft) + " "
+        fulltext = battery_icon(percentleft) + "   "
     elif state == "Full":
         fulltext = FA_PLUG + " "
         timeleft = ""
@@ -104,26 +104,25 @@ else:
             return "#FFFF66"
         return "#FFFFFF"
 
-    # make sure we use proper short vs full text
+    # make sure we use proper short vs full text even if they don't differ much
     shorttext = fulltext
     if os.environ.get('icon_only'):
         if os.environ.get('percent_color'):
-            form = '<span color="{}">{}%</span>'
+            form = '<span color="{}">{}</span>'
             fulltext = form.format(color(percentleft),fulltext.strip())
             shorttext = form.format(color(percentleft),shorttext.strip())
         else:
             fulltext = fulltext.strip()
             shorttext = shorttext.strip()
-
     else:
         if os.environ.get('percent_color'):
-            form =  '<span color="{}">{}%</span>'
-            fulltext += form.format(color(percentleft), percentleft)
-            shorttext += form.format(color(percentleft), percentleft)
+            form =  '<span color="{}">{}{}</span>'
+            fulltext += form.format(color(percentleft), percentleft, "%")
+            shorttext = form.format(color(percentleft), percentleft, "")
         else:
-            form =  '<span>{}%</span>'
-            fulltext += form.format(percentleft)
-            shorttext += form.format(percentleft)
+            form =  '<span>{}{}</span>'
+            fulltext += form.format(percentleft, "%")
+            shorttext = form.format(percentleft, "%")
         if os.environ.get('display_time_left'):
             fulltext += timeleft
 

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -48,9 +48,16 @@ else:
             if p>0:
                 percentleft_batteries.append(p)
             commasplitstatus_batteries.append(commasplitstatus)
-    state = state_batteries[0]
-    if state_batteries[0] == "Unknown":
-        state = state_batteries[1]
+    # Default battery state to unknown
+    state = "Unknown"
+    # Loop over batteries
+    for s in state_batteries:
+        # If the battery is anything but unknown, use it
+        if s != "Unknown":
+            state = s
+            # If one battery is full and one is charging/discharging, we use that state
+            if s != "Full":
+                state = s
     commasplitstatus = commasplitstatus_batteries[0]
     if percentleft_batteries:
         percentleft = int(sum(percentleft_batteries)/len(percentleft_batteries))
@@ -94,16 +101,24 @@ else:
     fulltext = label_form.format(default_label_color, battery_icon)
 
     def color(percent):
-        if percent < 10:
-            # exit code 33 will turn background red
-            return "#FFFFFF"
-        if percent < 20:
-            return "#FF3300"
-        if percent < 30:
-            return "#FF6600"
-        if percent < 40:
-            return "#FF9900"
-        return default_color
+        if os.environ.get('percent_color'):
+            if percent < 10:
+                # exit code 33 will turn background red
+                return "#FFFFFF"
+            if percent < 20:
+                return "#FF3300"
+            if percent < 30:
+                return "#FF6600"
+            if percent < 35:
+                return "#FCBD00"
+            return default_color
+        else:
+            return default_color
+
+    def gettimeleft():
+        if os.environ.get('display_time_left'):
+            return timeleft
+        return ""
 
     # make sure we use proper short vs full text even if they don't differ much
     shorttext = fulltext
@@ -116,17 +131,10 @@ else:
             fulltext = fulltext.strip()
             shorttext = shorttext.strip()
     else:
-        if os.environ.get('percent_color'):
-            form =  '<span font_desc="{}" color="{}">{}{}</span>'
-            fulltext += form.format(valuefont, color(percentleft), percentleft, "%")
-            shorttext = form.format(valuefont, color(percentleft), percentleft, "")
-        else:
-            form =  '<span font_desc="{}" >{}{}</span>'
-            fulltext += form.format(valuefont, percentleft, "%")
-            shorttext = form.format(valuefont, percentleft, "%")
-        if os.environ.get('display_time_left'):
-            form =  '<span font_desc="{}">{}</span>'
-            fulltext += form.format(valuefont, timeleft)
+        form =  '<span font_desc="{}" color="{}">{}{}{}</span>'
+        fulltext += form.format(valuefont, color(percentleft), percentleft, "%", gettimeleft())
+        shorttext = form.format(valuefont, color(percentleft), percentleft, "", "")
+
 
 print(fulltext)
 print(shorttext)

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -9,6 +9,7 @@
 
 import re
 from subprocess import check_output
+import os
 
 status = check_output(['acpi'], universal_newlines=True)
 
@@ -103,9 +104,15 @@ else:
             return "#FFFF66"
         return "#FFFFFF"
 
-    form =  '<span color="{}">{}%</span>'
-    fulltext += form.format(color(percentleft), percentleft)
-    fulltext += timeleft
+    if os.environ.get('percent_color'):
+        form =  '<span color="{}">{}%</span>'
+        fulltext += form.format(color(percentleft), percentleft)
+    else:
+        form =  '<span>{}%</span>'
+        fulltext += form.format(percentleft)
+    if os.environ.get('display_time_left'):
+        fulltext += timeleft
+    
 
 print(fulltext)
 print(fulltext)

--- a/scripts/battery2
+++ b/scripts/battery2
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2016 James Murphy
+# Licensed under the GPL version 2 only
+#
+# Modofied by Leo Palmer 2019
+#
+# A battery indicator blocklet script for i3blocks
+
+import re
+from subprocess import check_output
+
+status = check_output(['acpi'], universal_newlines=True)
+
+if not status:
+    # stands for no battery found
+    fulltext = "<span color='red'><span font='FontAwesome'>\uf00d \uf240</span></span>"
+    percentleft = 100
+else:
+    # if there is more than one battery in one laptop, the percentage left is 
+    # available for each battery separately, although state and remaining 
+    # time for overall block is shown in the status of the first battery 
+    batteries = status.split("\n")
+    state_batteries=[]
+    commasplitstatus_batteries=[]
+    percentleft_batteries=[]
+    time = ""
+    for battery in batteries:
+        if battery!='':
+            state_batteries.append(battery.split(": ")[1].split(", ")[0])
+            commasplitstatus = battery.split(", ")
+            if not time:
+                time = commasplitstatus[-1].strip()
+                # check if it matches a time
+                time = re.match(r"(\d+):(\d+)", time)
+                if time:
+                    time = ":".join(time.groups())
+                    timeleft = " ({})".format(time)
+                else:
+                    timeleft = ""
+
+            p = int(commasplitstatus[1].rstrip("%\n"))
+            if p>0:
+                percentleft_batteries.append(p)
+            commasplitstatus_batteries.append(commasplitstatus)
+    state = state_batteries[0]
+    commasplitstatus = commasplitstatus_batteries[0]
+    if percentleft_batteries:
+        percentleft = int(sum(percentleft_batteries)/len(percentleft_batteries))
+    else:
+        percentleft = 0
+
+    def battery_icon(percent):
+        if percent < 10:
+            # exit code 33 will turn background red
+            return "\uf244"
+        if percent < 25:
+            return "\uf243"
+        if percent < 50:
+            return "\uf242"
+        if percent < 75:
+            return "\uf241"
+        return "\uf240"
+
+    # stands for charging
+    FA_LIGHTNING = "<span color='yellow'><span font='FontAwesome'>\uf0e7</span></span>"
+
+    # stands for plugged in
+    FA_PLUG = "<span font='FontAwesome'>\uf1e6</span>"
+
+    # stands for unknown status of battery
+    FA_QUESTION = "<span font='FontAwesome'>\uf128</span>"
+
+
+    if state == "Discharging":
+        fulltext = battery_icon(percentleft) + " "
+    elif state == "Full":
+        fulltext = FA_PLUG + " "
+        timeleft = ""
+    elif state == "Unknown":
+        fulltext = FA_QUESTION + " " + FA_BATTERY + " "
+        timeleft = ""
+    else:
+        fulltext = FA_LIGHTNING + " " + FA_PLUG + " "
+
+    def color(percent):
+        if percent < 10:
+            # exit code 33 will turn background red
+            return "#FFFFFF"
+        if percent < 20:
+            return "#FF3300"
+        if percent < 30:
+            return "#FF6600"
+        if percent < 40:
+            return "#FF9900"
+        if percent < 50:
+            return "#FFCC00"
+        if percent < 60:
+            return "#FFFF00"
+        if percent < 70:
+            return "#FFFF33"
+        if percent < 80:
+            return "#FFFF66"
+        return "#FFFFFF"
+
+    form =  '<span color="{}">{}%</span>'
+    fulltext += form.format(color(percentleft), percentleft)
+    fulltext += timeleft
+
+print(fulltext)
+print(fulltext)
+if percentleft < 10:
+    exit(33)

--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -44,9 +44,11 @@ $cpu_usage eq -1 and die 'Can\'t find CPU information';
 # Get color values
 my $label_color = $ENV{'label_color'} || `xrescat i3xrocks.label.color`;
 my $value_color = $ENV{'color'} || `xrescat i3xrocks.value.color`;
+my $value_font = $ENV{'font'} || `xrescat i3xrocks.value.font`;
 
 # Print short_text, full_text
-printf "<span color='%s'></span><span color='%s'>%2d%%</span>\n", $label_color, $value_color, $cpu_usage;
-printf "<span color='%s'>%2d%%</span>\n", $value_color, $cpu_usage;
+printf "<span color='%s'></span><span font_desc='%s' color='%s'>%2d%%</span>\n", $label_color, $value_font, $value_color, $cpu_usage;
+printf "<span font_desc='%s' color='%s'>%2d%%</span>\n", $value_font, $value_color, $cpu_usage;
+
 
 exit 0;

--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use utf8;
 use Getopt::Long;
+use open ':std', ':encoding(UTF-8)';
 
 # default values
 my $t_warn = 50;
@@ -40,10 +41,11 @@ close(MPSTAT);
 
 $cpu_usage eq -1 and die 'Can\'t find CPU information';
 
-
+# Get color values
+my $label_color = $ENV{'label_color'} || `xrescat i3xrocks.label.color`;
 
 # Print short_text, full_text
-printf "<span font_desc='%s' color='%s'>%2d%%</span>\n", `xrescat i3xrocks.value.font`, `xrescat i3xrocks.value.color`, $cpu_usage;
-printf "<span font_desc='%s' color='%s'>%2d%%</span>\n", `xrescat i3xrocks.value.font`, `xrescat i3xrocks.value.color`, $cpu_usage;
+printf "<span color='%s'></span><span color='%s'>%2d%%</span>\n", $label_color, `xrescat i3xrocks.value.color`, $cpu_usage;
+printf "<span color='%s'>%2d%%</span>\n", `xrescat i3xrocks.value.color`, $cpu_usage;
 
 exit 0;

--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -43,9 +43,10 @@ $cpu_usage eq -1 and die 'Can\'t find CPU information';
 
 # Get color values
 my $label_color = $ENV{'label_color'} || `xrescat i3xrocks.label.color`;
+my $value_color = $ENV{'color'} || `xrescat i3xrocks.value.color`;
 
 # Print short_text, full_text
-printf "<span color='%s'></span><span color='%s'>%2d%%</span>\n", $label_color, `xrescat i3xrocks.value.color`, $cpu_usage;
-printf "<span color='%s'>%2d%%</span>\n", `xrescat i3xrocks.value.color`, $cpu_usage;
+printf "<span color='%s'></span><span color='%s'>%2d%%</span>\n", $label_color, $value_color, $cpu_usage;
+printf "<span color='%s'>%2d%%</span>\n", $value_color, $cpu_usage;
 
 exit 0;

--- a/scripts/keyboard_layout
+++ b/scripts/keyboard_layout
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s/\S*\s'([^']+).*/\1/"
+gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s/\S*\s\S*\s'([^']+).*/\1/"
+

--- a/scripts/keyboard_layout
+++ b/scripts/keyboard_layout
@@ -1,5 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s/\S*\s'([^']+).*/\1/"
-gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s/\S*\s\S*\s'([^']+).*/\1/"
+VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
+
+PANGO_START="<span color='${VALUE_COLOR}' font_desc='$(xrescat i3xrocks.value.font)'>"
+PANGO_END="</span>"
+
+gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s#\S*\s'([^']+).*#$PANGO_START\1$PANGO_END#"
+gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s#\S*\s\S*\s'([^']+).*#$PANGO_START\1$PANGO_END#"
 

--- a/scripts/keyboard_layout
+++ b/scripts/keyboard_layout
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
+VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color)}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
-PANGO_START="<span color='${VALUE_COLOR}' font_desc='$(xrescat i3xrocks.value.font)'>"
+PANGO_START="<span color=\"${VALUE_COLOR}\" font_desc=\"${VALUE_FONT}\">"
 PANGO_END="</span>"
 
-gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s#\S*\s'([^']+).*#$PANGO_START\1$PANGO_END#"
-gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s#\S*\s\S*\s'([^']+).*#$PANGO_START\1$PANGO_END#"
-
+gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s,\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
+gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s,\S*\s\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,0 +1,4 @@
+#!/bin/sh
+nmcli -t connection show --active | awk -F ':' '
+/tun0/{vpn="ON"} /vpn/{name=$1}
+END{if(vpn) printf("%s\n%s\n", name, vpn)}'

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,4 +1,14 @@
-#!/bin/sh
-nmcli -t connection show --active | awk -F ':' '
+#!/bin/bash
+
+CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
 /tun0/{vpn="ON"} /vpn/{name=$1}
-END{if(vpn) printf("%s\n%s\n", name, vpn)}'
+END{if(vpn) printf("%s", name)}')
+
+LABEL="<span color=\"${label_color}\">vpn: </span>"
+
+if [[ -z "$CONNECTION" ]]; then
+    exit 0
+else
+   echo "${LABEL}<span color=\"${color}\">$CONNECTION</span>" # full text
+   echo "<span color=\"${color}\">ON</span>" # short text
+fi

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -4,11 +4,13 @@ CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
 /tun0/{vpn="ON"} /vpn/{name=$1}
 END{if(vpn) printf("%s", name)}')
 
-LABEL="<span color=\"${label_color}\">vpn: </span>"
+LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
+VALUE_COLOR="${color:-$(xrescat i3xrocks.value.color)}"
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
 if [[ -z "$CONNECTION" ]]; then
     exit 0
 else
-   echo "${LABEL}<span color=\"${color}\">$CONNECTION</span>" # full text
-   echo "<span color=\"${color}\">ON</span>" # short text
+   echo "<span font_desc=\"${VALUE_FONT}\" color=\"${LABEL_COLOR}\">vpn: </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
+   echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">ON</span>" # short text
 fi

--- a/scripts/time
+++ b/scripts/time
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 DATE_FORMAT=`xrescat i3xrocks.date.format "+ %m-%d %H:%M "`
-echo "<span font_desc='`xrescat i3xrocks.value.font`' color='`xrescat i3xrocks.value.color`'>`date "$DATE_FORMAT"`</span>"
+LABEL_COLOR=${label_color:=$(xrescat i3xrocks.label.color)}
+VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
+echo "<span color='${LABEL_COLOR}' font='FontAwesome'></span><span color='${VALUE_COLOR}'>$(date "$DATE_FORMAT")</span>"

--- a/scripts/time
+++ b/scripts/time
@@ -1,5 +1,6 @@
 #!/bin/bash
 DATE_FORMAT=`xrescat i3xrocks.date.format "+ %m-%d %H:%M "`
-LABEL_COLOR=${label_color:=$(xrescat i3xrocks.label.color)}
-VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
-echo "<span color='${LABEL_COLOR}' font='FontAwesome'></span><span color='${VALUE_COLOR}'>$(date "$DATE_FORMAT")</span>"
+LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
+VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color)}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
+echo "<span color=\"${LABEL_COLOR}\" font=\"FontAwesome\"></span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$(date "$DATE_FORMAT")</span>"

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+INTERFACE="${BLOCK_INSTANCE:-wlan0}"
+
+# As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
+# connection (think desktop), the corresponding block should not be displayed.
+[[ ! -d /sys/class/net/${INTERFACE}/wireless ]] ||
+    [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]] && exit
+
+ESSID=$(/sbin/iwconfig $INTERFACE | perl -n -e'/ESSID:"(.*?)"/ && print $1')
+
+
+echo " $ESSID" # full text
+echo $ESSID # short text

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -4,9 +4,10 @@ DEFAULT_DEVICE=$(cat /proc/net/wireless | perl -ne '/(\w+):/ && print $1')
 
 INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
 
-VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
-LABEL_COLOR=${label_color:=$(xrescat i3xrocks.label.color)}
+VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color)}
+LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
 
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
 # connection (think desktop), the corresponding block should not be displayed.
@@ -16,5 +17,5 @@ LABEL_COLOR=${label_color:=$(xrescat i3xrocks.label.color)}
 ESSID=$(/sbin/iwconfig $INTERFACE | perl -n -e'/ESSID:"(.*?)"/ && print $1')
 
 
-echo "<span color=\"${LABEL_COLOR}\"> </span><span color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
-echo "<span color=\"${VALUE_COLOR}\">$ESSID</span>" # short text
+echo "<span color=\"${LABEL_COLOR}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
+echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # short text

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -4,6 +4,10 @@ DEFAULT_DEVICE=$(cat /proc/net/wireless | perl -ne '/(\w+):/ && print $1')
 
 INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
 
+VALUE_COLOR=${color:=$(xrescat i3xrocks.value.color)}
+LABEL_COLOR=${label_color:=$(xrescat i3xrocks.label.color)}
+
+
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
 # connection (think desktop), the corresponding block should not be displayed.
 [[ ! -d /sys/class/net/${INTERFACE}/wireless ]] ||
@@ -12,5 +16,5 @@ INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
 ESSID=$(/sbin/iwconfig $INTERFACE | perl -n -e'/ESSID:"(.*?)"/ && print $1')
 
 
-echo "<span> $ESSID</span>" # full text
-echo "<span>$ESSID</span>" # short text
+echo "<span color=\"${LABEL_COLOR}\"> </span><span color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
+echo "<span color=\"${VALUE_COLOR}\">$ESSID</span>" # short text

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -12,5 +12,5 @@ INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
 ESSID=$(/sbin/iwconfig $INTERFACE | perl -n -e'/ESSID:"(.*?)"/ && print $1')
 
 
-echo " $ESSID" # full text
-echo $ESSID # short text
+echo "<span> $ESSID</span>" # full text
+echo "<span>$ESSID</span>" # short text

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-INTERFACE="${BLOCK_INSTANCE:-wlan0}"
+DEFAULT_DEVICE=$(cat /proc/net/wireless | perl -ne '/(\w+):/ && print $1')
+
+INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
 
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
 # connection (think desktop), the corresponding block should not be displayed.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13341934/63204521-95d3a080-c0ec-11e9-8f0c-da19d57876b7.png)

This adds a few new blocklets to enhance the default set of blocklets.

Not sure about the colour on the Battery2 blocklet yet, but it's at least a handy visual guide for myself to remember to charge my laptop.
The Battery2 blocklet also supports multiple batteries which is something the default Battery blocklet doesn't. 