### PR TITLE
Update Wifi2 blocklet to use nmcli

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+regolith-i3xrocks-config (1.13-1ubuntu1~ppa2) disco; urgency=medium
+
+  * Update wifi2 blocklet to use nmcli for better UTF-8 compatibility.
+
+ -- Leo Palmer <leo.sunmo@gmail.com>  Tue, 17 Sep 2019 18:34:04 +1200
+
 regolith-i3xrocks-config (1.12-1ubuntu1~ppa2) disco; urgency=medium
 
   * Add attribution for recent contributions to copyright file.

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -6,6 +6,7 @@ LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
 ESSID=$(nmcli -t -f active,ssid dev wifi |  perl -n -e '/yes:(.*)/ && print $1')
-
-echo "<span color=\"${LABEL_COLOR}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
-echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # short text
+if [ ! -z "$ESSID" ]; then
+    echo "<span color=\"${LABEL_COLOR}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
+    echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # short text
+fi

--- a/scripts/wifi2
+++ b/scripts/wifi2
@@ -1,21 +1,11 @@
 #!/bin/bash
 
-DEFAULT_DEVICE=$(cat /proc/net/wireless | perl -ne '/(\w+):/ && print $1')
-
-INTERFACE="${BLOCK_INSTANCE:-${DEFAULT_DEVICE}}"
-
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color)}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
 
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
-# As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
-# connection (think desktop), the corresponding block should not be displayed.
-[[ ! -d /sys/class/net/${INTERFACE}/wireless ]] ||
-    [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]] && exit
-
-ESSID=$(/sbin/iwconfig $INTERFACE | perl -n -e'/ESSID:"(.*?)"/ && print $1')
-
+ESSID=$(nmcli -t -f active,ssid dev wifi |  perl -n -e '/yes:(.*)/ && print $1')
 
 echo "<span color=\"${LABEL_COLOR}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # full text
 echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$ESSID</span>" # short text


### PR DESCRIPTION
fixes regolith-linux/regolith-desktop#122

This is using a more modern commandline tool for network device discovery and management.
Works nicely with UTF-8 and requires less messing around in `/proc/` and `/sys/`

It does have this weird delay when it runs for the first time in a while, but not sure it matters much.