### PR TITLE
add wireguard support and fancy icon

### DIFF
--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -4,8 +4,8 @@ CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
 /wg0|tun0/{vpn="ON"}; {if(/wireguard|vpn/) {vpn_name=$1} else if (/tun0/){tun_name=$1}}
 END{if ( (vpn) && (vpn_name)) {printf("%s", vpn_name)}  else if( (vpn) && (tun_name)) {printf("%s", tun_name)}}')
 
-LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.vpn.label_color)}
-VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.vpn.color)}"
+LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.label.color)}
+VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.value.color)}"
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
 if [[ -z "$CONNECTION" ]]; then

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -4,7 +4,7 @@ CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
 /wg0|tun0/{vpn="ON"} /wireguard|tun|vpn/{name=$1}
 END{if(vpn) printf("%s", name)}')
 
-LABEL_COLOR=${vpn_color:-$(xrescat i3xrocks.vpn.color)}
+LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.vpn.label_color)}
 VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.vpn.color)}"
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
-/wg0|tun0/{vpn="ON"} /wireguard|tun0|vpn/{name=$1}
-END{if(vpn) printf("%s", name)}')
+/wg0|tun0/{vpn="ON"}; {if(/wireguard|vpn/) {vpn_name=$1} else if (/tun0/){tun_name=$1}}
+END{if ( (vpn) && (vpn_name)) {printf("%s", vpn_name)}  else if( (vpn) && (tun_name)) {printf("%s", tun_name)}}')
 
 LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.vpn.label_color)}
 VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.vpn.color)}"
@@ -12,5 +12,5 @@ if [[ -z "$CONNECTION" ]]; then
     exit 0
 else
    echo "<span color=\"${LABEL_COLOR}\" font=\"FontAwesome\"> </span> <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
-   echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">ON</span>" # short text
+   echo "<span color=\"${LABEL_COLOR}\" font=\"FontAwesome\"> </span>" # short text
 fi

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
-/wg0|tun0/{vpn="ON"} /wireguard|tun|vpn/{name=$1}
+/wg0|tun0/{vpn="ON"} /wireguard|tun0|vpn/{name=$1}
 END{if(vpn) printf("%s", name)}')
 
 LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.vpn.label_color)}

--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 CONNECTION=$(nmcli -t connection show --active | awk -F ':' '
-/tun0/{vpn="ON"} /vpn/{name=$1}
+/wg0|tun0/{vpn="ON"} /wireguard|tun|vpn/{name=$1}
 END{if(vpn) printf("%s", name)}')
 
-LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color)}
-VALUE_COLOR="${color:-$(xrescat i3xrocks.value.color)}"
+LABEL_COLOR=${vpn_color:-$(xrescat i3xrocks.vpn.color)}
+VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.vpn.color)}"
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
 if [[ -z "$CONNECTION" ]]; then
     exit 0
 else
-   echo "<span font_desc=\"${VALUE_FONT}\" color=\"${LABEL_COLOR}\">vpn: </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
+   echo "<span color=\"${LABEL_COLOR}\" font=\"FontAwesome\"> </span> <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
    echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">ON</span>" # short text
 fi


### PR DESCRIPTION
This one did not work for me using nordvpn. since it is called :tun:tun0 instead of :vpn:tun0. I also added support for wireguard and added a fancy icon :) Note that we must update the .Xresources file to add a green color to it in the i3xblock.vpn.color variable. (or just default grey color if we rather want that. I use a green color so that it is easier to see that im in "secure" mode)