### PR TITLE
adding focused-window-name to show title of focused window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 	$(INSTALL) -m0755 -D scripts/cpu_usage $(SCRIPT_TARGET)/cpu_usage
 	$(INSTALL) -m0755 -D scripts/disk $(SCRIPT_TARGET)/disk
 	$(INSTALL) -m0755 -D scripts/iface $(SCRIPT_TARGET)/iface
+	$(INSTALL) -m0755 -D scripts/focused_window_name $(SCRIPT_TARGET)/focused_window_name
 	$(INSTALL) -m0755 -D scripts/keyboard_layout $(SCRIPT_TARGET)/keyboard_layout
 	$(INSTALL) -m0755 -D scripts/keyindicator $(SCRIPT_TARGET)/keyindicator
 	$(INSTALL) -m0755 -D scripts/load_average $(SCRIPT_TARGET)/load_average

--- a/debian/copyright
+++ b/debian/copyright
@@ -35,6 +35,10 @@ Copyright: Copyright © 2014 Julien Bonjean <julien@bonjean.info>
            Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 License: GPL-3+
 
+Files: scripts/focused-window-name
+Copyright: Copyright © 2019 Bence Ferdinandy <bence@ferdinandy.com>
+License: GPL-3+
+
 Files: scripts/keyindicator
 Copyright: Copyright 2014 Marcelo Cerri <mhcerri at gmail dot com>
 License: GPL-3+

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -97,3 +97,10 @@ interval=10
 [time]
 interval=60
 
+# Show title of focused window
+[focused-window-name]
+label= 
+#interval=1
+#filter_list=evince libreoffice # uncomment to show only for these window instances
+#short_length=10 # uncomment to change maximum size of shortened text
+

--- a/i3xrocks.conf
+++ b/i3xrocks.conf
@@ -98,8 +98,8 @@ interval=10
 interval=60
 
 # Show title of focused window
-[focused-window-name]
-label= 
+#[focused-window-name]
+#label=  # uncomment to show an icon
 #interval=1
 #filter_list=evince libreoffice # uncomment to show only for these window instances
 #short_length=10 # uncomment to change maximum size of shortened text

--- a/scripts/focused-window-name
+++ b/scripts/focused-window-name
@@ -68,7 +68,7 @@ focused = i3.get_tree().find_focused()
 name = focused.name
 
 # LibreOffice adds it's own name at the end so we need to remove that
-if "LibreOffice" in name.split("-")[-1]:
+if "LibreOffice" in name.split("-")[-1] and focused.window_instance == "libreoffice":
     name = "-".join(name.split("-")[:-1])
 
 if len(filter_list) == 0:

--- a/scripts/focused-window-name
+++ b/scripts/focused-window-name
@@ -65,11 +65,17 @@ else:
 i3 = Connection()
 focused = i3.get_tree().find_focused()
 
+name = focused.name
+
+# LibreOffice adds it's own name at the end so we need to remove that
+if "LibreOffice" in name.split("-")[-1]:
+    name = "-".join(name.split("-")[:-1])
+
 if len(filter_list) == 0:
-    print(value_span(focused.name))
-    print(value_span(focused.name[:short_length]))
+    print(value_span(name))
+    print(value_span(name[:short_length]))
 else:
     if focused.window_instance in filter_list:
-        print(value_span(focused.name))
-        print(value_span(focused.name[:short_length]))
+        print(value_span(name))
+        print(value_span(name[:short_length]))
 

--- a/scripts/focused-window-name
+++ b/scripts/focused-window-name
@@ -25,10 +25,12 @@
 import sys
 import argparse
 import os
+import subprocess
 
 from i3ipc import Connection, Event
 
-
+def value_span(value):
+    return f'<span font_desc="{value_font}" color = "{value_color}" > {value} </span>'
 
 parser = argparse.ArgumentParser(description="Returns the title of the currently focused window")
 parser.add_argument("-f","--filter_list", nargs='+',help="only return window title if the window instance is in the provided list, eg. specifying libreoffice will result in only instance of libreoffice being returned")
@@ -37,6 +39,15 @@ args = parser.parse_args()
 
 filter_list_env = os.environ.get('filter_list')
 short_length_env = os.environ.get("short_length")
+
+value_color, err = subprocess.Popen(['xrescat', 'i3xrocks.value.color','#D8DEE9'], stdout=subprocess.PIPE).communicate()
+value_color = value_color.decode("utf-8")
+label_color, err = subprocess.Popen(['xrescat', 'i3xrocks.label.color','#7B8394'], stdout=subprocess.PIPE).communicate()
+label_color = label_color.decode("utf-8")
+value_font, err = subprocess.Popen(['xrescat', 'i3xrocks.value.font','Source Code Pro Medium 13'], stdout=subprocess.PIPE).communicate()
+value_font = value_font.decode("utf-8")
+
+
 
 if filter_list_env is None and args.filter_list is None:
     filter_list = []
@@ -55,10 +66,10 @@ i3 = Connection()
 focused = i3.get_tree().find_focused()
 
 if len(filter_list) == 0:
-    print(focused.name)
-    print(focused.name[:short_length])
+    print(value_span(focused.name))
+    print(value_span(focused.name[:short_length]))
 else:
     if focused.window_instance in filter_list:
-        print(focused.name)
-        print(focused.name[:short_length])
+        print(value_span(focused.name))
+        print(value_span(focused.name[:short_length]))
 

--- a/scripts/focused-window-name
+++ b/scripts/focused-window-name
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+
+#
+# Copyright 2019 Bence Ferdinandy <bence@ferdinandy.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# USAGE:
+#
+# Can read from environment variables (filter_list and short_length) or 
+# from command line arguments, but the latter takes precendence.
+#
+#
+import sys
+import argparse
+import os
+
+from i3ipc import Connection, Event
+
+
+
+parser = argparse.ArgumentParser(description="Returns the title of the currently focused window")
+parser.add_argument("-f","--filter_list", nargs='+',help="only return window title if the window instance is in the provided list, eg. specifying libreoffice will result in only instance of libreoffice being returned")
+parser.add_argument("-s","--short_length",type=int,help="max number of characters to print for short version")
+args = parser.parse_args()
+
+filter_list_env = os.environ.get('filter_list')
+short_length_env = os.environ.get("short_length")
+
+if filter_list_env is None and args.filter_list is None:
+    filter_list = []
+elif args.filter_list is None:
+    filter_list = filter_list_env.split()
+else:
+    filter_list = args.filter_list
+
+if short_length_env is None and args.short_length is None:
+    short_length = 10
+elif args.short_length is None:
+    short_length = int(short_length_env)
+else:
+    short_length = args.short_length
+i3 = Connection()
+focused = i3.get_tree().find_focused()
+
+if len(filter_list) == 0:
+    print(focused.name)
+    print(focused.name[:short_length])
+else:
+    if focused.window_instance in filter_list:
+        print(focused.name)
+        print(focused.name[:short_length])
+


### PR DESCRIPTION
This is I think my third pull request ever and the first one on a new function rather then just a tweak so I'm not sure if I did this right ...

Anyway, the script returns the title of the focused window. The short version is not really smart, but at least is short. It can also be used with command line arguments. I'm not sure this feature will be useful for anything, but I coded it with that first and then realized I need to use environment variables if I want a nice config in i3xrocks.