### PR TITLE
Update memory

### DIFF
--- a/scripts/memory
+++ b/scripts/memory
@@ -42,8 +42,8 @@ awk -v type=$TYPE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" 
 END {
 	# full text
 	if (type == "swap")
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>", lc, li, vf, vc, (swap_total-swap_free)/1024/1024)
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (swap_total-swap_free)/1024/1024)
 	else
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>", lc, li, vf, vc, mem_free/1024/1024)
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, mem_free/1024/1024)
 }
 ' /proc/meminfo


### PR DESCRIPTION
Adding a new line should fix the i3-wm error

```log
Jan 31 15:50:40 grid i3-gnome-flashback.desktop[7208]: [libi3] ../../i3-gaps-wm-4.17.1/libi3/font.c Using Pango font Source Code Pro Medium 13,FontAwesome, size 13
```