### PR TITLE
Remove instance value in battery3

### DIFF
--- a/config
+++ b/config
@@ -77,9 +77,10 @@ min_width=100%
 # Battery indicator
 #
 # Displays total percentage charge left of specified battery.
+# You can specify the instance by adding:
+# instance=BAT0
 [battery3]
 interval=30
-instance=BAT0
 
 # Rofication
 #


### PR DESCRIPTION
By default, base on the script in `battery3` it will look for any device as per this line:

```bash
BATT_DEVICE=$(upower -e | grep -o 'BAT[0-9]' | head -n 1)
```

Removing the `instance=BAT0` in the sample config will still work.
If defined, it will use the one that is set by the user as per this line: `BLOCK_INSTANCE`

```bash
__UPOWER_INFO=$(upower --show-info "/org/freedesktop/UPower/devices/battery_${BLOCK_INSTANCE:-$BATT_DEVICE}")
```