### PR TITLE
Change awk logic to detect right connection name.

### DIFF
--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 CONNECTION=$(LC_ALL=C nmcli -t connection show --active | awk -F ':' '
-/wg0|tun0|tap0/{vpn="ON"}; {if(/wireguard|vpn/) {vpn_name=$1} else if (/tun0/){tun_name=$1} else if (/tap0/){tun_name=$1}}
-END{if ( (vpn) && (vpn_name)) {printf("%s", vpn_name)}  else if( (vpn) && (tun_name)) {printf("%s", tun_name)}}')
-
+{ if($3 == "vpn") {
+    vpn_name=$1
+  } else if ($3 == "tun"){
+    tun_name=$1
+  } else if ($3 == "tap"){
+    tun_name=$1
+  }
+}
+END{if (vpn_name) {printf("%s", vpn_name)}  else if(tun_name) {printf("%s", tun_name)}}')
 LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.label.color)}
 VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.value.color)}"
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}


### PR DESCRIPTION
I made a few changes to the part of the script detecting and choosing the right vpn connection name.
Here is a working example from nmcli:
```MY_VPN:ID1:vpn:wlo1
MY_WIFI:ID2:802-11-wireless:wlo1
vpn0:ID3:tun:vpn0
docker0:ID4:bridge:docker0
```
With the previous version, I got none. The new one finds and selects `MY_VPN`. But I am not sure about other test cases, especially with wireguard.