### PR TITLE
Take only first volume and status from amixer

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -59,7 +59,7 @@ mixer_info() {
 
 # Returns "on" if not mute, "off" if mute
 status() {
-  mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p"
+  mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p" | head -n 1
 }
 
 icon() {
@@ -76,7 +76,7 @@ value() {
   STATUS=$(status)
   if [ $STATUS == "on" ]
   then
-    VAL=`mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p"`
+    VAL=`mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1`
     echo "$VAL$UNIT"
   else
     echo ""


### PR DESCRIPTION
My system reports two audio values, i.e.:
`amixer -D pulse get Master`

```
Simple mixer control 'Master',0
  Capabilities: pvolume pswitch pswitch-joined
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 65536
  Mono:
  Front Left: Playback 15309 [23%] [on]
  Front Right: Playback 15309 [23%] [on]
```
This change proposes to just take the first. I don't know if this is good practice or not, would appreciate any input.