### PR TITLE
Determine pulseaudio using `pactl list`

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -36,8 +36,8 @@ UNIT="${2:-%}"
 # For ALSA users, you may use "default" for your primary card
 # or you may use hw:# where # is the number of the card desired
 MIXER="default"
-[ -n "$(lsmod | grep pulse)" ] && MIXER="pulse"
-[ -n "$(lsmod | grep jack)" ] && MIXER="jackplug"
+pactl list 1>/dev/null && MIXER="pulse"
+lsmod | grep -q jack && MIXER="jackplug"
 MIXER="${3:-$MIXER}"
 
 # The instance option sets the control to report and configure


### PR DESCRIPTION
Replaces lsmod check with `pactl list` return code. On my distro, pulse doesn't appear in lsmod. Similarly, just check the retcode for grep rather than doing a string substitution

Again, this might not be the best fix, e.g. what if pulse audio is installed, but lists no sinks/devices etc.