### PR TITLE
i3xrocks battery blocklet should not emit the charging span when fully charged

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -29,16 +29,16 @@ CHARGE_STATE=$(get_battery_status)
 
 if [ -z "$BATT_PERCENT" ]; then
     exit 0
-    elif [ "$BATT_PERCENT" -ge 0 ] && [ "$BATT_PERCENT" -le 20 ]; then
+elif [ "$BATT_PERCENT" -ge 0 ] && [ "$BATT_PERCENT" -le 20 ]; then
     LABEL_ICON=$(xrescat i3xrocks.label.battery0 E)
     VALUE_COLOR=$(xrescat i3xrocks.critical.color red)
-    elif [ "$BATT_PERCENT" -ge 20 ] && [ "$BATT_PERCENT" -le 50 ]; then
+elif [ "$BATT_PERCENT" -ge 20 ] && [ "$BATT_PERCENT" -le 50 ]; then
     LABEL_ICON=$(xrescat i3xrocks.label.battery20 L)
     VALUE_COLOR=$(xrescat i3xrocks.error.color orange)
-    elif [ "$BATT_PERCENT" -ge 50 ] && [ "$BATT_PERCENT" -le 80 ]; then
+elif [ "$BATT_PERCENT" -ge 50 ] && [ "$BATT_PERCENT" -le 80 ]; then
     LABEL_ICON=$(xrescat i3xrocks.label.battery50 M)
     VALUE_COLOR=$(xrescat i3xrocks.nominal white)
-    elif [ "$BATT_PERCENT" -ge 80 ] && [ "$BATT_PERCENT" -le 98 ]; then
+elif [ "$BATT_PERCENT" -ge 80 ] && [ "$BATT_PERCENT" -le 98 ]; then
     LABEL_ICON=$(xrescat i3xrocks.label.battery80 F)
     VALUE_COLOR=$(xrescat i3xrocks.nominal white)
 else
@@ -46,17 +46,22 @@ else
     VALUE_COLOR=$(xrescat i3xrocks.nominal white)
 fi
 
+ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
+VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $BATT_PERCENT%</span>"
+
 if [ -z "$CHARGE_STATE" ]; then
     exit 0
-    elif [ "$CHARGE_STATE" == "discharging" ]; then
+elif [ "$CHARGE_STATE" == "discharging" ]; then
     CHARGE_ICON=$(xrescat i3xrocks.label.dn D)
-    elif [ "$CHARGE_STATE" == "charging" ]; then
+    CHARGE_SPAN="<span color=\"${LABEL_COLOR}\">$CHARGE_ICON</span>"
+elif [ "$CHARGE_STATE" == "charging" ]; then
     CHARGE_ICON=$(xrescat i3xrocks.label.up C)
+    CHARGE_SPAN="<span color=\"${LABEL_COLOR}\">$CHARGE_ICON</span>"
 else
-    CHARGE_ICON=$(echo -e '\u2003')
+    CHARGE_SPAN=""
 fi
 
-echo "<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $BATT_PERCENT%</span><span color=\"${LABEL_COLOR}\">$CHARGE_ICON</span>"
+echo "${ICON_SPAN}${VALUE_SPAN}${CHARGE_SPAN}"
 
 if [ ! -z "$button" ]; then
     /usr/bin/i3-msg -q exec /usr/bin/gnome-control-center power


### PR DESCRIPTION
As for the subject, this PR addresses a minor graphical issue where the `battery` i3xrocks blocklet displays a larger gap when the battery is fully charged.

This happens because the "charging" span in the script is emitted in any case, even if the battery is not charging or discharging.

With this PR, the `battery` blocklet only emits the "charging" span if the battery is actually charging or discharging.