### PR TITLE
fixed width output

### DIFF
--- a/scripts/media-player
+++ b/scripts/media-player
@@ -4,11 +4,12 @@
 STATUS=$(playerctl status 2> /dev/null)
 
 # use given values or fall back to parameters from xresources
+FIELD_WIDTH=${icon:-$(xrescat i3xrocks.value.mediaplayerwidth 25)}
 PLAYING_ICON=${icon:-$(xrescat i3xrocks.label.mediaplaying "")}
 PAUSED_ICON=${icon:-$(xrescat i3xrocks.label.mediapaused "")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
-VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
 
 # assign the appropriate icon
 #
@@ -28,17 +29,17 @@ TITLE="$(playerctl metadata title)"
 # print resulting information (fulltext)
 text="${ARTIST} - ${TITLE}"
 length=${#text}
-width=25
+width=$FIELD_WIDTH
 
 if [[ $length > $width ]]; then
-    text="${text:0:$(( width - 3 ))}..."
+    TEXT="${text:0:$(( width - 3 ))}..."
 else
-    text=$(printf "%-${width}s" "$text")
+    TEXT=$(printf "%-${width}s" "$text")
 fi
 
 echo "<span color=\"${LABEL_COLOR}\">${ICON}</span>\
 <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> \
-${text}</span>"
+${TEXT}</span>"
 
 # for shorttext, only print the appropriate glyph
 echo "$ICON"

--- a/scripts/media-player
+++ b/scripts/media-player
@@ -26,12 +26,22 @@ ARTIST="$(playerctl metadata artist)"
 TITLE="$(playerctl metadata title)"
 
 # print resulting information (fulltext)
+text="${ARTIST} - ${TITLE}"
+length=${#text}
+width=25
+
+if [[ $length > $width ]]; then
+    text="${text:0:$(( width - 4 ))}..."
+else
+    text=$(printf "%-${width}s\n" "$text")
+fi
+
 echo "<span color=\"${LABEL_COLOR}\">${ICON}</span>\
 <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> \
-${ARTIST} - ${TITLE}</span>"
+${text}</span>"
 
 # for shorttext, only print the appropriate glyph
-echo $ICON
+echo "$ICON"
 
 # rudimentary controls via mouse clicks
 #

--- a/scripts/media-player
+++ b/scripts/media-player
@@ -31,9 +31,9 @@ length=${#text}
 width=25
 
 if [[ $length > $width ]]; then
-    text="${text:0:$(( width - 4 ))}..."
+    text="${text:0:$(( width - 3 ))}..."
 else
-    text=$(printf "%-${width}s\n" "$text")
+    text=$(printf "%-${width}s" "$text")
 fi
 
 echo "<span color=\"${LABEL_COLOR}\">${ICON}</span>\


### PR DESCRIPTION
This PR fixes the width of the output field to 25 characters. The original script depending on the song title and artists sometimes could take up the whole bar since there was no limit! This will takes care of it. If the output exceeds 25 characters it will add 3 dots to show that the text is cut off

![image](https://user-images.githubusercontent.com/13016644/80541329-935e6180-8970-11ea-89c7-656f91d5daee.png)

![image](https://user-images.githubusercontent.com/13016644/80541258-745fcf80-8970-11ea-8fe7-b720da860256.png)
