### PR TITLE
Fix focused-window-name plugin

### DIFF
--- a/conf.d/10_focused-window-name
+++ b/conf.d/10_focused-window-name
@@ -1,6 +1,8 @@
 # Show title of focused window
 [focused-window-name]
-label=  # uncomment to show an icon
+# Uncomment to show an icon
+# label=
 interval=1
-#filter_list=evince libreoffice # uncomment to show only for these window instances
+# Uncomment to show only for these window instances
+# filter_list=evince libreoffice
 short_length=10


### PR DESCRIPTION
Windows names were wrongly including the string `uncomment to show an icon`