### PR TITLE
Udpated gsetting parameter lookup

### DIFF
--- a/scripts/keyboard-layout
+++ b/scripts/keyboard-layout
@@ -6,5 +6,5 @@ VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 PANGO_START="<span color=\"${VALUE_COLOR}\" font_desc=\"${VALUE_FONT}\">"
 PANGO_END="</span>"
 
-gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s,\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
-gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s,\S*\s\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
+gsettings get org.gnome.desktop.input-sources sources | sed -r "s,\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
+gsettings monitor org.gnome.desktop.input-sources sources | sed -u -r "s,\S*\s\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"


### PR DESCRIPTION
The `sources` parameters is what works for me. `mru-sources` parameter is empty causing the block to display non-sense.

![Screenshot from 2020-05-02 17-38-06](https://user-images.githubusercontent.com/223608/80868593-05e67e80-8c9c-11ea-8de3-aef93e064f13.png)
