### PR TITLE
Updates to the volume blocklet script

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -72,13 +72,8 @@ icon() {
 }
 
 value() {
-    STATUS=$(status)
-    if [ "$STATUS" == "on" ]; then
-        VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
-        echo "$VAL$UNIT"
-    else
-        echo ""
-    fi
+    VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
+    echo "$VAL$UNIT"
 }
 
 case $BLOCK_BUTTON in

--- a/scripts/volume
+++ b/scripts/volume
@@ -73,11 +73,11 @@ case $BLOCK_BUTTON in
 5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
 esac
 
-LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
+LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#E6E1CF")}
 
 if [ "$(status)" == "on" ]; then
     ICON=${icon_on:-$(xrescat i3xrocks.label.sound S)}
-    VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
+    VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#E6E1CF")}
 else
     ICON=${icon_mute:-$(xrescat i3xrocks.label.mute M)}
     VALUE_COLOR=${warn_color:-$(xrescat i3xrocks.warning "#FFD580")}

--- a/scripts/volume
+++ b/scripts/volume
@@ -48,34 +48,34 @@ SCONTROL="${BLOCK_INSTANCE:-$(
         head -n1
 )}"
 
-capability() { # Return "Capture" if the device is a capture device
+mixer_capability() { # Return "Capture" if the device is a capture device
     amixer -D $MIXER get $SCONTROL |
         sed -n "s/  Capabilities:.*cvolume.*/Capture/p"
 }
 
 mixer_info() {
-    amixer -D $MIXER get $SCONTROL $(capability)
+    amixer -D $MIXER get $SCONTROL $(mixer_capability)
 }
 
 # Returns "on" if not mute, "off" if mute
-status() {
+mixer_status() {
     mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p" | head -n 1
 }
 
-value() {
+mixer_value() {
     VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
     echo "$VAL$UNIT"
 }
 
 case $BLOCK_BUTTON in
-3) amixer -q -D $MIXER sset $SCONTROL $(capability) toggle ;; # right click, mute/unmute
-4) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}+ unmute ;; # scroll up, increase
-5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
+3) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) toggle ;; # right click, mute/unmute
+4) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}+ unmute ;; # scroll up, increase
+5) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
 esac
 
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#E6E1CF")}
 
-if [ "$(status)" == "on" ]; then
+if [ "$(mixer_status)" == "on" ]; then
     ICON=${icon_on:-$(xrescat i3xrocks.label.sound S)}
     VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#E6E1CF")}
 else
@@ -84,6 +84,6 @@ else
 fi
 
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
-VALUE=$(value)
+VALUE=$(mixer_value)
 
 echo "<span color=\"${LABEL_COLOR}\">${ICON}</span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $VALUE</span>"

--- a/scripts/volume
+++ b/scripts/volume
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020 Guillaume Deflaux
+# Copyright (c) 2020 Guillaume Deflaux, Marco Buzzanca
 #
 # Based on the work of:
 #   2014 Julien Bonjean <julien@bonjean.info>
@@ -24,10 +24,10 @@
 
 # The first parameter sets the step to change the volume by (and units to display)
 # This may be in in % or dB (eg. 5% or 3dB)
-STEP="${1:-5}"
+STEP="${1:-$(xrescat i3xrocks.volume.step 5)}"
 
 # The second parameter sets the unit. It can be '%' or 'dB' only.
-UNIT="${2:-%}"
+UNIT="${2:-$(xrescat i3xrocks.volume.unit %)}"
 
 # The third parameter overrides the mixer selection
 # For PulseAudio users, use "pulse"
@@ -37,7 +37,7 @@ UNIT="${2:-%}"
 MIXER="default"
 pactl list 1>/dev/null && MIXER="pulse"
 lsmod | grep -q jack && MIXER="jackplug"
-MIXER="${3:-$MIXER}"
+MIXER="${3:-$(xrescat i3xrocks.volume.mixer $MIXER)}"
 
 # The instance option sets the control to report and configure
 # This defaults to the first control of your selected mixer

--- a/scripts/volume
+++ b/scripts/volume
@@ -62,15 +62,6 @@ status() {
     mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p" | head -n 1
 }
 
-icon() {
-    STATUS=$(status)
-    if [ "$STATUS" == "on" ]; then
-        echo $ICON_ON
-    else
-        echo $ICON_MUTE
-    fi
-}
-
 value() {
     VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
     echo "$VAL$UNIT"
@@ -82,12 +73,16 @@ case $BLOCK_BUTTON in
 5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
 esac
 
-ICON_ON=${icon_on:-$(xrescat i3xrocks.label.sound S)}
-ICON_MUTE=${icon_mute:-$(xrescat i3xrocks.label.mute M)}
-ICON=$(icon)
-
-VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
+
+if [ "$(status)" == "on" ]; then
+    ICON=${icon_on:-$(xrescat i3xrocks.label.sound S)}
+    VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
+else
+    ICON=${icon_mute:-$(xrescat i3xrocks.label.mute M)}
+    VALUE_COLOR=${warn_color:-$(xrescat i3xrocks.warning "#FFD580")}
+fi
+
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 VALUE=$(value)
 

--- a/scripts/volume
+++ b/scripts/volume
@@ -22,7 +22,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 # The first parameter sets the step to change the volume by (and units to display)
 # This may be in in % or dB (eg. 5% or 3dB)
 STEP="${1:-5}"
@@ -43,14 +42,15 @@ MIXER="${3:-$MIXER}"
 # The instance option sets the control to report and configure
 # This defaults to the first control of your selected mixer
 # For a list of the available, use `amixer -D $Your_Mixer scontrols`
-SCONTROL="${BLOCK_INSTANCE:-$(amixer -D $MIXER scontrols |
+SCONTROL="${BLOCK_INSTANCE:-$(
+    amixer -D $MIXER scontrols |
         sed -n "s/Simple mixer control '\([A-Za-z0-9 ]*\)',0/\1/p" |
         head -n1
 )}"
 
 capability() { # Return "Capture" if the device is a capture device
     amixer -D $MIXER get $SCONTROL |
-    sed -n "s/  Capabilities:.*cvolume.*/Capture/p"
+        sed -n "s/  Capabilities:.*cvolume.*/Capture/p"
 }
 
 mixer_info() {
@@ -59,34 +59,32 @@ mixer_info() {
 
 # Returns "on" if not mute, "off" if mute
 status() {
-  mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p" | head -n 1
+    mixer_info | sed -n "s/.*\[\(on\|off\)\].*/\1/p" | head -n 1
 }
 
 icon() {
-  STATUS=$(status)
-  if [ "$STATUS" == "on" ]
-  then
-    echo $ICON_ON
-  else
-    echo $ICON_MUTE
-  fi
+    STATUS=$(status)
+    if [ "$STATUS" == "on" ]; then
+        echo $ICON_ON
+    else
+        echo $ICON_MUTE
+    fi
 }
 
 value() {
-  STATUS=$(status)
-  if [ "$STATUS" == "on" ]
-  then
-    VAL=`mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1`
-    echo "$VAL$UNIT"
-  else
-    echo ""
-  fi
+    STATUS=$(status)
+    if [ "$STATUS" == "on" ]; then
+        VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
+        echo "$VAL$UNIT"
+    else
+        echo ""
+    fi
 }
 
 case $BLOCK_BUTTON in
-    3) amixer -q -D $MIXER sset $SCONTROL $(capability) toggle ;;  # right click, mute/unmute
-    4) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}+ unmute ;; # scroll up, increase
-    5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
+3) amixer -q -D $MIXER sset $SCONTROL $(capability) toggle ;; # right click, mute/unmute
+4) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}+ unmute ;; # scroll up, increase
+5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
 esac
 
 ICON_ON=${icon_on:-$(xrescat i3xrocks.label.sound S)}

--- a/scripts/volume
+++ b/scripts/volume
@@ -69,8 +69,8 @@ mixer_value() {
 
 case $BLOCK_BUTTON in
 3) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) toggle ;; # right click, mute/unmute
-4) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}+ unmute ;; # scroll up, increase
-5) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}- unmute ;; # scroll down, decrease
+4) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}+ ;; # scroll up, increase
+5) amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}- ;; # scroll down, decrease
 esac
 
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#E6E1CF")}


### PR DESCRIPTION
This relatively localized PR actually changes many things in the volume blocklet. I do not expect all of the changes to be included upstream, so I have separated the changes in different commits, in order to make it easier to pick what to include, in a way.

### Changes
- `STEP`, `UNIT` and `MIXER` are now searched in `XResources` definitions before falling back to the default values. The three relevant definitions are `i3xrocks.volume.step`, `i3xrocks.volume.unit` and `i3xrocks.volume.mixer`.
- The volume level is now displayed even if the control is muted. There are two reasons for this:
  - The blocklet size stays consistent when muting/unmuting.
  - It can be useful to know the volume level before unmuting.
- The volume level is displayed in warning color when muted, to better highlight the reason the sound is not working,
- If the volume is changed while muted, the mixer is no longer automatically unmuted. This can be useful when you want to change the output volume before unmuting (maybe because it was too loud).
- Consistent function names and whitespace.