### PR TITLE
Update keyboard-layout

### DIFF
--- a/scripts/keyboard-layout
+++ b/scripts/keyboard-layout
@@ -6,5 +6,5 @@ VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 PANGO_START="<span color=\"${VALUE_COLOR}\" font_desc=\"${VALUE_FONT}\">"
 PANGO_END="</span>"
 
-gsettings get org.gnome.desktop.input-sources sources | sed -r "s,\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
-gsettings monitor org.gnome.desktop.input-sources sources | sed -u -r "s,\S*\s\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
+gsettings get org.gnome.desktop.input-sources mru-sources | sed -r "s,\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"
+gsettings monitor org.gnome.desktop.input-sources mru-sources | sed -u -r "s,\S*\s\S*\s'([^']+).*,$PANGO_START\1$PANGO_END,"


### PR DESCRIPTION
GSettings has a special option, `mru-sources` (as in Most Recently Used sources) which is specified to change order with every layout change.
The original version uses `sources` which doesn't guarantee any reordering, and didn't work reliably for me (on Ubuntu 20.04)

**PS.** Probably adding an explicit license to this repository would be a good idea; just in case, I explicitly grant all rights to this contribution of mine to Regolith project.