### PR TITLE
Convert repo to use gbp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-debian export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+debian/files

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-.pc
-debian/files
-.nvimlog
-.vscode
-.vstags

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 debian/files
+.vscode/
+.pc
+.vstags

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+regolith-i3xrocks-config (3.0.26-1) bionic; urgency=medium
+
+  [ Taher Chegini ]
+  * Add todo blocklet (#54)
+
+  [ Ken Gilmer ]
+  * Initial upstream branch.
+  * New upstream version 3.0.25
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 24 May 2020 20:54:03 -0700
+
 regolith-i3xrocks-config (3.0.25-2) bionic; urgency=medium
 
   * Trying w/ debhelper v11 based on build error. 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: regolith-i3xrocks-config
 Section: x11
 Priority: optional
 Maintainer: Ken Gilmer <kgilmer@gmail.com>
-Build-Depends: debhelper (>= 11)
+Build-Depends: debhelper (>= 12)
 Standards-Version: 4.1.2
 Homepage: https://github.com/regolith-linux/regolith-desktop
 Vcs-Git: https://github.com/regolith-linux/regolith-i3xrocks-config.git

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+upstream-tree=master


### PR DESCRIPTION
This PR uses the guide http://honk.sigxcpu.org/projects/git-buildpackage/manual-html/gbp.import.convert.html to convert the repo to use the `gbp` tool.  In essence (as I understand it) this is to separate the source (upstream) from the Debian files (master).

## Testing

Built the source package locally, no errors.  One warning regarding text in the copyright file.