### PR TITLE
Exit gracefully if the focused window does not have a name

### DIFF
--- a/scripts/focused-window-name
+++ b/scripts/focused-window-name
@@ -72,19 +72,16 @@ else:
 i3 = Connection()
 focused = i3.get_tree().find_focused()
 
-try:
-    name = focused.name
+if focused is None:
+    sys.exit()
 
-    # LibreOffice adds it's own name at the end so we need to remove that
-    if "LibreOffice" in name.split("-")[-1] and focused.window_instance == "libreoffice":
-        name = "-".join(name.split("-")[:-1])
+name = focused.name if hasattr(focused, "name") and focused.name is not None else sys.exit()
+instance = focused.window_instance if hasattr(focused, "window_instance") else None
 
-    if len(filter_list) == 0:
-        print(value_span(name))
-        print(value_span(name[:short_length]))
-    else:
-        if focused.window_instance in filter_list:
-            print(value_span(name))
-            print(value_span(name[:short_length]))
-except AttributeError as e:
-    pass
+# LibreOffice adds its own name at the end so we need to remove that
+if "LibreOffice" in name.split("-")[-1] and instance == "libreoffice":
+    name = "-".join(name.split("-")[:-1])
+
+if len(filter_list) == 0 or instance in filter_list:
+    print(value_span(name))
+    print(value_span(name[:short_length]))


### PR DESCRIPTION
Some windows do not have names and every time I get a Ubuntu crash dialog for this script. Now the script checks if `name` is actually a string.