### PR TITLE
Use `MemAvailable` to indicate memory usage

### DIFF
--- a/scripts/memory
+++ b/scripts/memory
@@ -33,6 +33,9 @@ awk -v type=$TYPE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" 
 /^Cached:/ {
 	mem_free+=$2
 }
+/^MemAvailable:/ {
+	mem_available=$2
+}
 /^SwapTotal:/ {
 	swap_total=$2
 }
@@ -40,10 +43,13 @@ awk -v type=$TYPE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" 
 	swap_free=$2
 }
 END {
+	# fallback for mem_available
+	if (mem_available == "")
+		mem_available=mem_free
 	# full text
 	if (type == "swap")
 		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (swap_total-swap_free)/1024/1024)
 	else
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, mem_free/1024/1024)
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, mem_available/1024/1024)
 }
 ' /proc/meminfo


### PR DESCRIPTION
This change sets the amount of free memory from the `MemAvailable` field
of `/proc/meminfo` when it is available.  If not available, the existing behavior
acts as a fall-back. This field is available in Linux kernels since early 2014.

To quote the documentation, `MemAvailable` is:
> An estimate of how much memory is available for starting new
> applications, without swapping. Calculated from MemFree,
> SReclaimable, the size of the file LRU lists, and the low
> watermarks in each zone.
> The estimate takes into account that the system needs some
> page cache to function well, and that not all reclaimable
> slab will be reclaimable, due to items being in use. The
> impact of those factors will vary from system to system.

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773