### PR TITLE
Add Pango formatted special characters

### DIFF
--- a/scripts/media-player
+++ b/scripts/media-player
@@ -37,6 +37,11 @@ else
     TEXT=$(printf "%-${width}s" "$text")
 fi
 
+# sanitize text for Pango parsing
+TEXT=${TEXT//&/&amp;}
+TEXT=${TEXT//>/&gt;}
+TEXT=${TEXT//</&lt;}
+
 echo "<span color=\"${LABEL_COLOR}\">${ICON}</span>\
 <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> \
 ${TEXT}</span>"


### PR DESCRIPTION
This will make sure the i3 pango formatter displays these special (in the Pango language) characters properly.

I only tested this with the ampersand (&) as I couldn't find any songs on Spotify with "<>" characters :shrug: 

This is using the same method I used in https://github.com/leosunmo/spotify-blocklet/blob/master/main.go#L114 which has worked great so far.