### PR TITLE
[IMPR] Show aggregated battery percentage

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -19,11 +19,12 @@ get_battery_status() {
 # Returns:
 #   The battery's percentage, without the %.
 get_battery_percent() {
-    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print $2}'
+    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print $2}' | cut -d',' -f1
 }
 
-BATT_DEVICE=$(upower -e | grep -o 'BAT[0-9]' | head -n 1)
-__UPOWER_INFO=$(upower --show-info "/org/freedesktop/UPower/devices/battery_${BLOCK_INSTANCE:-$BATT_DEVICE}")
+BATT_DEVICE="DisplayDevice"
+__UPOWER_INFO=$(upower --show-info "/org/freedesktop/UPower/devices/${BLOCK_INSTANCE:-$BATT_DEVICE}")
+
 
 BATT_PERCENT=$(get_battery_percent)
 CHARGE_STATE=$(get_battery_status)


### PR DESCRIPTION
This is a fix for issue #77 . It adds support for showing aggregate battery percentage for 1 or more batteries. It relies on upower's [DisplayDevice](https://upower.freedesktop.org/docs/UPower.html#id-1.2.3.8.5).

If a user prefers to show a specific battery (e.g. battery_BAT0) they can do so by setting `BLOCK_INSTANCE` to `battery_BAT0`.

The `get_battery_percent` function has also been improved to handle cases where the returned percentage is float with a comma used as a floating point separator. 

