### PR TITLE
[FIX] Fixes dissapearing indicator when value is 0

### DIFF
--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -205,9 +205,10 @@ else
   AN="$(echo "$AX"/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
 fi
 
-for s in $RN $TN $AN; do
-  [[ "$s" == "$(printf "%s\n-0.0001\n" "$s" | sort -g | head -1)" ]] && exit
-done
+# Set non-valid values to 0
+[[ "$RN" == "$(printf "%s\n-0.0001\n" "$RN" | sort -g | head -1)" ]] && RN=0
+[[ "$TN" == "$(printf "%s\n-0.0001\n" "$TN" | sort -g | head -1)" ]] && TN=0
+[[ "$AN" == "$(printf "%s\n-0.0001\n" "$AN" | sort -g | head -1)" ]] && AN=0
 
 # output net usage using pango markup
 if [ "$RT" = "up" ]; then


### PR DESCRIPTION
Fixes issue #73 by setting the value of RN, TN and AN to 0 instead of exiting if the value is 0 or invalid.