### PR TITLE
Remove decimal places from battery number

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -19,7 +19,7 @@ get_battery_status() {
 # Returns:
 #   The battery's percentage, without the %.
 get_battery_percent() {
-    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print $2}' | cut -d',' -f1
+    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print $2}' | cut -d',' -f1 | cut -d'.' -f1 
 }
 
 BATT_DEVICE="DisplayDevice"

--- a/scripts/battery
+++ b/scripts/battery
@@ -19,7 +19,7 @@ get_battery_status() {
 # Returns:
 #   The battery's percentage, without the %.
 get_battery_percent() {
-    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print $2}' | cut -d',' -f1 | cut -d'.' -f1 
+    echo "$__UPOWER_INFO" | awk -W posix '$1 == "percentage:" { gsub("%","",$2); print int($2)}'
 }
 
 BATT_DEVICE="DisplayDevice"


### PR DESCRIPTION
The current command removes numbers in the format `##,###`; however, my computer's output is `##.###` so I added an additional `cut` command to remove both types of decimals. Note, it doesn't round.

[before]
![image](https://user-images.githubusercontent.com/441217/96774850-90ec3a00-13de-11eb-8c7b-e6fb784a0912.png)

[after]
![image](https://user-images.githubusercontent.com/441217/96774991-c2650580-13de-11eb-915b-4f34ab81df0b.png)
