### PR TITLE
reading from xresources now

### DIFF
--- a/scripts/next-workspace
+++ b/scripts/next-workspace
@@ -2,28 +2,47 @@
 
 import i3ipc
 import argparse
+import subprocess
+import re
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
             description = "Find the next non-opened workspace and go there.")
     parser.add_argument('-s','--startnum',type=int,default = 1,
-        help="Set smallest workspace number, usually change to 0 if anything.")
+        help="DEPRECATED")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-mv","--move-window",action="store_true",
             help="Instead of going to next non-opened workspace, move current window there.")
     group.add_argument("-mvf","--move-window-and-follow",action="store_true",
             help="Move current window to next non-opened workspace and follow.")
     args = parser.parse_args()
+   
+    # Get names of the Xserver
+    mapping_names = {}
+    output, err = subprocess.Popen(["xrdb","-query"],stdout=subprocess.PIPE).communicate()
+    output = output.decode().split("\n")
+    output = [
+            line.split("\t")[1] 
+            for line in output 
+            if re.search("^i3-wm\.workspace\...\.name:",line)
+            ]
+    mapping_names = {
+            int(line.split(":")[0]) : line.split(":")[1]
+            for line in output
+            }
 
-    startnum = args.startnum
+    startnum = min(mapping_names.keys())
+    endnum = 50
     i3 = i3ipc.Connection()
     workspaces = i3.get_workspaces()
     nums = {w.num for w in workspaces}
-    font = workspaces[0].name.split("'")[1]
-    s_ = {x for x in range(args.startnum,args.startnum + 20)}
+    s_ = {x for x in range(startnum,endnum)}
     targetnum = min(s_ - nums)
-    targetstring = "{0}:<span font_desc='{1}'> {0} </span>".format(targetnum,font)
+    try:
+        targetstring = f"{targetnum}:{mapping_names[targetnum]}"
+    except KeyError:
+        targetstring = f"{targetnum}:{targetnum}"
 
     if args.move_window or args.move_window_and_follow:
         i3.command("move container workspace " + targetstring)


### PR DESCRIPTION
This pull request fixes the bug reported in https://github.com/regolith-linux/regolith-desktop/issues/470 as it will now use `xrdb -query` to read the workspace names directly from the configurations set by regolith. This also means we can deprecate the `--startnum` flag, since we can now read the smallest workspace number from the configs.