### PR TITLE
Restore original behavior of mouse actions on volume

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -72,13 +72,17 @@ mixer_value() {
     fi
 }
 
-ACTION_1=$(xrescat i3xrocks.action.volume.left "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) toggle")
-ACTION_2=$(xrescat i3xrocks.action.volume.middle "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}+")
-ACTION_3=$(xrescat i3xrocks.action.volume.right "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}-")
+ACTION_1=$(xrescat i3xrocks.action.volume.left "true")
+ACTION_2=$(xrescat i3xrocks.action.volume.middle "true")
+ACTION_3=$(xrescat i3xrocks.action.volume.right "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) toggle")
+ACTION_4=$(xrescat i3xrocks.action.volume.scrollup "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}+")
+ACTION_5=$(xrescat i3xrocks.action.volume.scrolldn "amixer -q -D $MIXER sset $SCONTROL $(mixer_capability) ${STEP}${UNIT}-")
 case $BLOCK_BUTTON in
     1) eval $ACTION_1 ;;
     2) eval $ACTION_2 ;;
     3) eval $ACTION_3 ;;
+    4) eval $ACTION_4 ;;
+    5) eval $ACTION_5 ;;
 esac
 
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#E6E1CF")}


### PR DESCRIPTION
This was broken in https://github.com/regolith-linux/regolith-i3xrocks-config/commit/2bfab21c15a9d730aaf9885bd777122f2ef72c16#diff-18e70f7d8538e1b83ef4439d10ed0ac98c433f6551932b2d172544b23b84b637

Also add overrides for every possible action (left, middle, right mouse buttons and scrolling actions)