### PR TITLE
Fix for button handling of the net-traffic script

### DIFF
--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -30,19 +30,8 @@ UNIT=${UNIT:-}
 BPS=false
 ULEV=2
 
-# Handle button event
-if [ "x${BUTTON}" == "x1" ] ; then
-  if [ "$INT_TYPE" == "W" ]; then
-    ACTION=$(xrescat i3xrocks.action.net-traffic.left "/usr/bin/gnome-control-center --class=floating_window wifi")
-    /usr/bin/i3-msg -q exec "$ACTION"
-  else
-    ACTION=$(xrescat i3xrocks.action.net-traffic.right "/usr/bin/gnome-control-center --class=floating_window network")
-    /usr/bin/i3-msg -q exec "$ACTION"
-  fi
-fi
-
 # determine the net interface name
-IF=$(ip route get 1.1.1.1 | grep -Po '(?<=dev\s)\w+' | cut -f1 -d ' ')
+IF="$(ip route show default | awk '{ print $5 }')"
   IF="${BLOCK_INSTANCE:-${IF}}"
 
     [ "$IF" = "" ] && exit
@@ -219,4 +208,15 @@ elif [ "$RT" = "total" ]; then
   echo "$(lspan "${NIC}")$(fspan "$AN$SUF")"
 else
   echo "$(lspan "${NIC}")$(fspan "$RN$SUF")$(lspan "${DN}")$(fspan "$TN$SUF")$(lspan "${UP}")"
+fi
+
+# Handle button event
+if [ "x${BUTTON}" == "x1" ] ; then
+  if [ "$INT_TYPE" == "W" ]; then
+    ACTION=$(xrescat i3xrocks.action.net-traffic.left "/usr/bin/gnome-control-center --class=floating_window wifi")
+    /usr/bin/i3-msg -q exec "$ACTION"
+  else
+    ACTION=$(xrescat i3xrocks.action.net-traffic.right "/usr/bin/gnome-control-center --class=floating_window network")
+    /usr/bin/i3-msg -q exec "$ACTION"
+  fi
 fi


### PR DESCRIPTION
Previously, the button handling was run before the variable `INT_TYPE` was initialized. This should've been detected earlier (especially by `shellcheck`) but wasn't. With the recently added tests the script should now run "flawlessly".

I've also exchanged the default route parsing logic for a shorter, more efficient one-liner.