### PR TITLE
Add extra location information to weather API request

### DIFF
--- a/scripts/weather
+++ b/scripts/weather
@@ -38,7 +38,7 @@ if [ -z "$WEATHER_UNITS" ]; then
 fi
 
 # Defaults to IP address location
-IP_LOCATION="$(curl -s https://ipapi.co/city/),$(curl -s https://ipapi.co/region/)"
+IP_LOCATION="$(curl -s -N https://ipapi.co/yaml/ | awk 'BEGIN { FS=": " } /^country: / {country=$2} /^postal: / {gsub(/[\\^'\''|'\''$]/, "",$2) ; postal=$2} /^city: / {city=$2} /^region: / {region=$2} END { print city","region","postal","country}')"
 VALUE_WEATHER_LOCATION=${weather_location:-$(xrescat i3xrocks.weather.location "$IP_LOCATION")}
 ENCODED_VALUE_WEATHER_LOCATION=$(urlencode "$VALUE_WEATHER_LOCATION")
 VALUE_WEATHER_ERROR_MESSAGE=${error_message:-$(xrescat i3xrocks.weather.error_message "")}


### PR DESCRIPTION
I live in Vienna, Austria, and noticed that the weather block did not match with current conditions in my area. I did some digging, and it seems that  `IP_LOCATION` was being set to "Vienna,Vienna" (since Vienna the city is also [Vienna the region](https://en.wikipedia.org/wiki/States_of_Austria)). When passed to the wttr.in service, this returns information about Vienna, South Dakota ([https://wttr.in/Vienna%2CVienna](https://wttr.in/Vienna%2CVienna)).

Adding the country code to the request is not enough to resolve this ambiguity, which I tested using a VPN set to a location in the USA. This gave me a location of "Clifton,New Jersey,US". The weather service returns the weather for Clifton in California: [https://wttr.in/Clifton%2CNew%20Jersey%2CUS](https://wttr.in/Clifton%2CNew%20Jersey%2CUS)

After further digging, I found that the least amount of ambiguity for the weather service can be obtained by passing it the postcode and country code. In the case of Vienna, that is [https://wttr.in/Vienna%2CVienna%2C1120%2CAT](https://wttr.in/Vienna%2CVienna%2C1120%2CAT). In the case of Clifton, New Jersey, that is [https://wttr.in/Clifton%2CNew%20Jersey%2C07014%2CUS](https://wttr.in/Clifton%2CNew%20Jersey%2C07014%2CUS)

This patch changes the geolocation method to only make a single request, and parses the resulting YAML for the four relevant fields. `awk` is included in the base Ubuntu system, and this code works with both `mawk` and `gawk` variants. I can also provide a version that does four separate requests, which is closer to the original code.
