### PR TITLE
Rewrote net-traffic script, fixes #91

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt update -qq
-          apt install --no-install-recommends -y iproute2 bc
+          apt install --no-install-recommends -y iproute2 bc silversearcher-ag
           cp tests/xrescat_mock /usr/bin/xrescat
           cp tests/i3-msg_mock /usr/bin/i3-msg
       - name: Run net-traffic test

--- a/conf.d/30_net-traffic
+++ b/conf.d/30_net-traffic
@@ -1,5 +1,3 @@
 # Displays network load
 [net-traffic]
-# Uncomment the next line to display in bits
-# command=/usr/share/i3xrocks/net-traffic-new -b
 interval=10

--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -6,7 +6,7 @@ set -Eeu -o pipefail
 UP=${label_icon:-$(xrescat i3xrocks.label.up " up")}
 DN=${label_icon:-$(xrescat i3xrocks.label.dn " dn")}
 BUTTON=${button:-}
-DLY=${DLY:-1}
+DLY=${DLY:-5}
 RT=${RT:-}
 
 # determine the net interface name

--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -2,6 +2,55 @@
 
 set -Eeu -o pipefail
 
+# some default values for arguments"
+UP=${label_icon:-$(xrescat i3xrocks.label.up " up")}
+DN=${label_icon:-$(xrescat i3xrocks.label.dn " dn")}
+BUTTON=${button:-}
+DLY=${DLY:-1}
+RT=${RT:-}
+
+# determine the net interface name
+IF="${BLOCK_INSTANCE:-$(ip route show default | awk '{ print $5 }')}"
+[ "$IF" = "" ] && exit
+
+IF_PATH="/sys/class/net/${IF}"
+
+if [ -d "${IF_PATH}/wireless" ] ; then
+  NIC=${label_icon:-$(xrescat i3xrocks.label.wifi )}
+  INT_TYPE="W"
+else
+  NIC=${label_icon:-$(xrescat i3xrocks.label.wired )}
+  INT_TYPE="C"
+fi
+
+# read dev file and compute net usage
+RX1=$(cat "${IF_PATH}"/statistics/rx_bytes)
+TX1=$(cat "${IF_PATH}"/statistics/tx_bytes)
+
+sleep "${DLY}"
+
+RX2=$(cat "${IF_PATH}"/statistics/rx_bytes)
+TX2=$(cat "${IF_PATH}"/statistics/tx_bytes)
+
+RX_DIFF=$(echo "($RX2-$RX1)/$DLY" | bc)
+TX_DIFF=$(echo "($TX2-$TX1)/$DLY" | bc)
+RX=$(echo "${RX_DIFF}" | numfmt --to iec --format %f)
+TX=$(echo "${TX_DIFF}" | numfmt --to iec --format %f)
+AX=$(echo "($RX_DIFF+$TX_DIFF)" | bc | numfmt --to iec --format %f)
+
+# Add a B for bytes at the end if the string is missing a letter
+if [[ "${RX}" =~ ^[0-9]+$ ]] ; then
+  RX="${RX}B"
+fi
+
+if [[ "${TX}" =~ ^[0-9]+$ ]] ; then
+  TX="${TX}B"
+fi
+
+if [[ "${AX}" =~ ^[0-9]+$ ]] ; then
+  AX="${AX}B"
+fi
+
 # span for text
 fspan() {
   echo "<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> ${1}</span>"
@@ -17,197 +66,15 @@ VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 
-# read the dev file for extracting net usage
-GET="cat /proc/net/dev"
-
-# some default values for arguments"
-UP=${label_icon:-$(xrescat i3xrocks.label.up " up")}
-DN=${label_icon:-$(xrescat i3xrocks.label.dn " dn")}
-BUTTON=${button:-}
-DLY=${DLY:-1}
-RT=${RT:-}
-UNIT=${UNIT:-}
-BPS=false
-ULEV=2
-
-# determine the net interface name
-IF="$(ip route show default | awk '{ print $5 }')"
-  IF="${BLOCK_INSTANCE:-${IF}}"
-
-    [ "$IF" = "" ] && exit
-
-# set net icon based on wire or wireless connection
-case "$IF" in
-  e*)
-    NIC=${label_icon:-$(xrescat i3xrocks.label.wired )}
-    INT_TYPE="C"
-    ;;
-  w*)
-    NIC=${label_icon:-$(xrescat i3xrocks.label.wifi )}
-    INT_TYPE="W"
-    ;;
-esac
-
-# get arguments
-while getopts i:a:u:e:t:U:D:lhvb option
-do
-  case "${option}"
-    in
-    i)
-    IF=${OPTARG};;
-    a)
-      RT=${OPTARG};;
-    u)
-      UNIT=${OPTARG};;
-    b)
-      BPS=true;;
-    e)
-      ULEV=${OPTARG};;
-    t)
-      DLY=${OPTARG};;
-    h)
-      echo "Usage: nettraffic [OPTION]"
-      echo "Options:"
-      echo -e "  -i  (%ifname%)\t Specify which network interface to monitor. By"
-      echo -e "    \t\t\t default it is detected automatically."
-      echo -e "  -a  (up|dn|total)\t Shows which data to display. Default is both."
-      echo -e "  -u  (K|KB|M|MB)\t Units to show the data in. Automatic if not specified."
-      echo -e "  -b  \t Show in bits per second (Kbps, Mbps - small b)."
-      echo -e "  -e  (0|1|2|3|4|5)\t Level of units displayed. (0 for none, 1 for K, 2 for KB, 3 for K/s,"
-      echo -e "    \t\t\t 4 for Kb/s, 5 for KB/s). Default of 2."
-      echo -e "  -t  (%integer%)\t Set the interval for the data update. Default is 1."
-      echo -e "  -v\t\t\t Prints version number."
-      echo -e "  -h\t\t\t Prints this help."
-      echo "Script adapted from http://github.com/ma-santoso/nettrafic/"
-      exit;;
-    v)
-      echo "$NAME, version $VERSION";
-      exit;;
-    *)
-      exit;;
-  esac
-done
-
-if [[ "$BPS" = true ]]; then
-  ULEV=4
-fi
-
-# set units
-if [ "$UNIT" = "MB" ] || [ "$UNIT" = "M" ]; then
-  FAC=1048576
-  case "$ULEV"
-    in
-    0) SUF="";;
-    1) SUF=" M";;
-    2) SUF="MB";;
-    3) SUF="M/s";;
-    4) SUF="Mb/s";;
-    *) SUF="MB/s";;
-  esac
-elif [ "$UNIT" = "KB" ] || [ "$UNIT" = "K" ]; then
-  FAC=1024
-  case "$ULEV"
-    in
-    0) SUF="";;
-    1) SUF=" K";;
-    2) SUF="KB";;
-    3) SUF="K/s";;
-    4) SUF="Kb/s";;
-    *) SUF="KB/s";;
-  esac
-elif [ "$UNIT" = "B" ]; then
-  FAC=1
-  case "$ULEV"
-    in
-    0) SUF="";;
-    1) SUF=" B";;
-    2) SUF=" B";;
-    3) SUF="b/s";;
-    4) SUF="b/s";;
-    *) SUF="B/s";;
-  esac
-fi
-
-RN="0.0"
-TN="0.0"
-AN="0.0"
-
-# read dev file and compute net usage
-RX1=$($GET | grep "$IF" | awk '{print $2}')
-TX1=$($GET | grep "$IF" | awk '{print $10}')
-
-sleep "${DLY}"
-
-RX2=$($GET | grep "$IF" | awk '{print $2}')
-TX2=$($GET | grep "$IF" | awk '{print $10}')
-
-RX=$(echo "scale = 0; ($RX2-$RX1)/$DLY" | bc -l)
-TX=$(echo "scale = 0; ($TX2-$TX1)/$DLY" | bc -l)
-AX=$(echo "scale = 0; $RX+$TX" | bc -l)
-
-# set net unit automatically
-if [[ -z "${UNIT}" ]]; then
-  if [ "$RX" -ge 102400 ] || [ "$TX" -ge 102400 ]; then
-    FAC=1048576
-    case "$ULEV"
-      in
-      0) SUF="";;
-      1) SUF=" M";;
-      2) SUF="MB";;
-      3) SUF="M/s";;
-      4) SUF="Mb/s";;
-      *) SUF="MB/s";;
-    esac
-  elif [ "$RX" -ge 100 ] || [ "$TX" -ge 100 ]; then
-    FAC=1024
-    case "$ULEV"
-      in
-      0) SUF="";;
-      1) SUF=" K";;
-      2) SUF="KB";;
-      3) SUF="K/s";;
-      4) SUF="Kb/s";;
-      *) SUF="KB/s";;
-    esac
-  else
-    FAC=1
-    case "$ULEV"
-      in
-      0) SUF="";;
-      1) SUF=" B";;
-      2) SUF=" B";;
-      3) SUF="b/s";;
-      4) SUF="b/s";;
-      *) SUF="B/s";;
-    esac
-  fi
-fi
-
-# format net usage output with fixed width
-if [[ "$BPS" = true ]] ; then
-  RN="$(echo \("$RX"\)*8/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-  TN="$(echo \("$TX"\)*8/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-  AN="$(echo \("$AX"\)*8/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-else
-  RN="$(echo "$RX"/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-  TN="$(echo "$TX"/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-  AN="$(echo "$AX"/"$FAC" | bc -l | awk '{ printf("%4.1f", $1)}')"
-fi
-
-# Set non-valid values to 0
-[[ "$RN" == "$(printf "%s\n-0.0001\n" "$RN" | sort -g | head -1)" ]] && RN=0
-[[ "$TN" == "$(printf "%s\n-0.0001\n" "$TN" | sort -g | head -1)" ]] && TN=0
-[[ "$AN" == "$(printf "%s\n-0.0001\n" "$AN" | sort -g | head -1)" ]] && AN=0
-
 # output net usage using pango markup
 if [ "$RT" = "up" ]; then
-  echo "$(lspan "${NIC}")$(fspan "$TN$SUF")$(lspan "${UP}")"
+  echo "$(lspan "${NIC}")$(fspan "$TX")$(lspan "${UP}")"
 elif [ "$RT" = "down" ] || [ "$RT" = "dn" ]; then
-  echo "$(lspan "${NIC}")$(fspan "$RN$SUF")$(lspan "${DN}")"
+  echo "$(lspan "${NIC}")$(fspan "$RX")$(lspan "${DN}")"
 elif [ "$RT" = "total" ]; then
-  echo "$(lspan "${NIC}")$(fspan "$AN$SUF")"
+  echo "$(lspan "${NIC}")$(fspan "$AX")"
 else
-  echo "$(lspan "${NIC}")$(fspan "$RN$SUF")$(lspan "${DN}")$(fspan "$TN$SUF")$(lspan "${UP}")"
+  echo "$(lspan "${NIC}")$(fspan "$RX")$(lspan "${DN}")$(fspan "$TX")$(lspan "${UP}")"
 fi
 
 # Handle button event

--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -10,7 +10,7 @@ DLY=${DLY:-1}
 RT=${RT:-}
 
 # determine the net interface name
-IF="${BLOCK_INSTANCE:-$(ip route show default | awk '{ print $5 }')}"
+IF="${BLOCK_INSTANCE:-$(ip route show default | awk 'NR==1 { print $5 }')}"
 [ "$IF" = "" ] && exit
 
 IF_PATH="/sys/class/net/${IF}"

--- a/tests/net-traffic_test.sh
+++ b/tests/net-traffic_test.sh
@@ -5,6 +5,14 @@ set -Eeux -o pipefail
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "${SCRIPT_DIR}/"
 
+# Regular syntax
+[ "2" -eq "$(../scripts/net-traffic | ag -o '(?<=\>\s)(\d{1,4}|\d{1,3},?\d{0,1}?)[GMKB](?=\<)' | wc -l)" ]
+
+# up, down, total as RT
+for summary in up down total ; do
+    [ "1" -eq "$(RT=${summary} ../scripts/net-traffic | ag -o '(?<=\>\s)(\d{1,4}|\d{1,3},?\d{0,1}?)[GMKB](?=\<)' | wc -l)" ]
+done
+
 # Test the two button inputs
 button=1
 export button


### PR DESCRIPTION
Completely rewrote the net-traffic script (well, almost) to use `numfmt` instead of coming up with our own routine. Also uses `sysfs` instead of `proc` filtering now to determine the device type (with potential to add more devices) and traffic deltas.

Also added tests, which are regexp-based for now, but better than nothing.