### PR TITLE
Fix click event in memory rock

### DIFF
--- a/scripts/memory
+++ b/scripts/memory
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+BUTTON=${button:-}
 TYPE="${BLOCK_INSTANCE:-mem}"
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.memory M)}
@@ -54,7 +55,7 @@ END {
 }
 ' /proc/meminfo
 
-if [[ "x${BUTTON}" == "x1" ]]; then
+if [ "x${BUTTON}" == "x1" ]; then
     ACTION=$(xrescat i3xrocks.action.memory "/usr/bin/gnome-system-monitor --class=floating_window --show-resources-tab")
     /usr/bin/i3-msg -q exec "$ACTION"
 fi


### PR DESCRIPTION
Memory rock on click event was not functioning due to a missing initialization of the BUTTON variable.