### PR TITLE
Change memory rock default full text

### DIFF
--- a/scripts/memory
+++ b/scripts/memory
@@ -20,8 +20,9 @@ LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.memory M)}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 DISPLAY=${display:-$(xrescat i3xrocks.memory.display "free")}
+PERCENTAGE=${percentage:-$(xrescat i3xrocks.memory.percentage "false")}
 
-awk -v type=$TYPE -v display=$DISPLAY -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
+awk -v type=$TYPE -v display=$DISPLAY -v percentage=$PERCENTAGE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
 /^MemTotal:/ {
 	mem_total=$2
 }
@@ -52,13 +53,19 @@ END {
 		to_display = swap_free/1024/1024
 		if (display == "used")
 			to_display = swap_total/1024/1024 - to_display
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
+		if (percentage == "true")
+			printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %02d%%</span>\n", lc, li, vf, vc, 100 * to_display / (swap_total/1024/1024))
+		else
+			printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
 	}
 	else {
 		to_display = mem_free/1024/1024
 		if (display == "used")
 			to_display = mem_total/1024/1024 - to_display
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
+		if (percentage == "true")
+			printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %02d%%</span>\n", lc, li, vf, vc, 100 * to_display / (mem_total/1024/1024))
+		else
+			printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
 	}
 }
 ' /proc/meminfo

--- a/scripts/memory
+++ b/scripts/memory
@@ -19,8 +19,9 @@ VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.memory M)}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
+DISPLAY=${display:-$(xrescat i3xrocks.memory.display "free")}
 
-awk -v type=$TYPE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
+awk -v type=$TYPE -v display=$DISPLAY -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
 /^MemTotal:/ {
 	mem_total=$2
 }
@@ -47,10 +48,18 @@ END {
 	if (mem_available == "")
 		mem_available=mem_free
 	# full text
-	if (type == "swap")
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (swap_total-swap_free)/1024/1024)
-	else
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (mem_total-mem_available)/1024/1024)
+	if (type == "swap") {
+		to_display = swap_free/1024/1024
+		if (display == "used")
+			to_display = swap_total/1024/1024 - to_display
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
+	}
+	else {
+		to_display = mem_free/1024/1024
+		if (display == "used")
+			to_display = mem_total/1024/1024 - to_display
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, to_display)
+	}
 }
 ' /proc/meminfo
 

--- a/scripts/memory
+++ b/scripts/memory
@@ -50,7 +50,7 @@ END {
 	if (type == "swap")
 		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (swap_total-swap_free)/1024/1024)
 	else
-		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, mem_available/1024/1024)
+		printf("<span color=\"%s\">%s</span><span font_desc=\"%s\" color=\"%s\"> %.1fG</span>\n", lc, li, vf, vc, (mem_total-mem_available)/1024/1024)
 }
 ' /proc/meminfo
 

--- a/scripts/memory
+++ b/scripts/memory
@@ -19,8 +19,8 @@ VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.memory M)}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
-DISPLAY=${display:-$(xrescat i3xrocks.memory.display "free")}
 PERCENTAGE=${percentage:-$(xrescat i3xrocks.memory.percentage "false")}
+DISPLAY=${display:-$(xrescat i3xrocks.memory.display "free")}
 
 awk -v type=$TYPE -v display=$DISPLAY -v percentage=$PERCENTAGE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
 /^MemTotal:/ {

--- a/scripts/memory
+++ b/scripts/memory
@@ -18,11 +18,11 @@ TYPE="${BLOCK_INSTANCE:-mem}"
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.memory M)}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
-VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
+DISP=${display:-$(xrescat i3xrocks.memory.display "free")}
 PERCENTAGE=${percentage:-$(xrescat i3xrocks.memory.percentage "false")}
-DISPLAY=${display:-$(xrescat i3xrocks.memory.display "free")}
 
-awk -v type=$TYPE -v display=$DISPLAY -v percentage=$PERCENTAGE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
+awk -v type=$TYPE -v display=$DISP -v percentage=$PERCENTAGE -v vc="$VALUE_COLOR" -v li="$LABEL_ICON" -v lc="$LABEL_COLOR" -v vf="$VALUE_FONT" '
 /^MemTotal:/ {
 	mem_total=$2
 }


### PR DESCRIPTION
Memory rock default full text shows memory available, while swap shows the one currently in use.
This aligns the default full text to the swap behavior.

It may be a matter of preference, but I feel like showing the memory currently in use is what a user would expect from this rock.
