### PR TITLE
Fix disk-capacity button clicks, add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,7 @@ jobs:
         shell: bash
         run: |
           tests/temp_test.sh
+      - name: Run disk-capacity test
+        shell: bash
+        run: |
+          tests/disk-capacity_test.sh

--- a/scripts/disk-capacity
+++ b/scripts/disk-capacity
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,11 +18,14 @@
 # Returns:
 #   The disk's available space in GB
 
+set -Eeux -o pipefail
+
 LABEL="${MNT:-/}"
-export LABEL
+BUTTON="${button:-}"
+export LABEL BUTTON
 
 get_disk_avail_gb() {
-    AVAIL_GB=$(df -hP "${LABEL}" |grep -vE '^Filesystem' | awk '{print $4}')
+    AVAIL_GB=$(df -h --output=avail "${LABEL}" | awk 'FNR == 2 {print $1}')
 }
 
 get_disk_avail_gb
@@ -35,6 +38,6 @@ VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 echo "<span color=\"${LABEL_COLOR}\">${LABEL_ICON}</span><span font_desc=\"${VALUE_FONT}\" color=\"${LABEL_COLOR}\"> $LABEL:</span> <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$AVAIL_GB</span>"
 
 if [ "x${BUTTON}" == "x1" ]; then
-    ACTION=$(xrescat i3xrocks.action.disk-capacity "/usr/bin/gnome-disks --class=floating_window power")
+    ACTION=$(xrescat i3xrocks.action.disk-capacity "/usr/bin/gnome-disks --class=floating_window")
     /usr/bin/i3-msg -q exec "$ACTION"
 fi

--- a/scripts/disk-capacity
+++ b/scripts/disk-capacity
@@ -18,7 +18,7 @@
 # Returns:
 #   The disk's available space in GB
 
-set -Eeux -o pipefail
+set -Eeu -o pipefail
 
 LABEL="${MNT:-/}"
 BUTTON="${button:-}"

--- a/tests/disk-capacity_test.sh
+++ b/tests/disk-capacity_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -Eeux -o pipefail
+
+echo ${BASH_SOURCE[0]}
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+cd "${SCRIPT_DIR}"
+
+# Initial run without defining a device
+PATH="$(pwd)/fixtures/disk-capacity/first:${PATH}"
+OUTPUT=$(../scripts/disk-capacity)
+echo "${OUTPUT}" | grep -q -P '\>133G\<'
+
+# Now with a device set
+MNT="/mnt"
+export MNT
+
+PATH="$(pwd)/fixtures/disk-capacity/second:${PATH}"
+OUTPUT=$(../scripts/disk-capacity)
+echo "${OUTPUT}" | grep -q -P '\>213G\<'

--- a/tests/fixtures/disk-capacity/first/df
+++ b/tests/fixtures/disk-capacity/first/df
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "${3}" == "/" ]; then
+    echo "Avail
+ 133G"
+fi

--- a/tests/fixtures/disk-capacity/second/df
+++ b/tests/fixtures/disk-capacity/second/df
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set +x
-
 if [ "${3}" == "/mnt" ]; then
     echo "Avail
  213G"

--- a/tests/fixtures/disk-capacity/second/df
+++ b/tests/fixtures/disk-capacity/second/df
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set +x
+
+if [ "${3}" == "/mnt" ]; then
+    echo "Avail
+ 213G"
+fi


### PR DESCRIPTION
`disk-capacity` is using `sh`, which doesn't support the syntax added for the button click guard. Fixed by using `bash` instead.

Also slightly changed the way we're getting the free capacity to be less cumbersome to parse and only use `awk` instead of `grep` _and_ `awk`.

Also added tests.