### PR TITLE
Use awk instead of bash printf to avoid octal conversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,7 @@ jobs:
         shell: bash
         run: |
           tests/disk-capacity_test.sh
+      - name: Run todo test
+        shell: bash
+        run: |
+          tests/todo_test.sh

--- a/scripts/todo
+++ b/scripts/todo
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+set -Eeu -o pipefail
+
+BUTTON="${button:-}"
 
 # get font and icon specifics from xresource file
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
@@ -7,7 +11,7 @@ LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
 
 # format net usage output with fixed width
-COUNT="$(printf "%2d" "$(td count)")"
+COUNT="$(td count | awk '{printf "%2d", $1}')"
 
 # output net usage using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
@@ -15,6 +19,6 @@ VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $COUNT</
 
 echo "${ICON_SPAN}${VALUE_SPAN}"
 
-if [ -n "$button" ]; then
+if [ "x${BUTTON}" == "x1" ]; then
     /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive'"
 fi

--- a/tests/fixtures/todo/first/td
+++ b/tests/fixtures/todo/first/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "0\n"

--- a/tests/fixtures/todo/fourth/td
+++ b/tests/fixtures/todo/fourth/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "122\n"

--- a/tests/fixtures/todo/second/td
+++ b/tests/fixtures/todo/second/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "1\n"

--- a/tests/fixtures/todo/third/td
+++ b/tests/fixtures/todo/third/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "22\n"

--- a/tests/todo_test.sh
+++ b/tests/todo_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -Eeux -o pipefail
+
+echo ${BASH_SOURCE[0]}
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+cd "${SCRIPT_DIR}"
+
+# Make sure we can handle 0 with leading space
+PATH="$(pwd)/fixtures/todo/first:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s{2}0\<'
+
+# Make sure we can handle 1 with leading space
+PATH="$(pwd)/fixtures/todo/second:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s{2}1\<'
+
+# Make sure we can handle 22 without leading space
+PATH="$(pwd)/fixtures/todo/third:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s22\<'
+
+# Make sure we can handle 122 without leading space
+PATH="$(pwd)/fixtures/todo/fourth:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s122\<'


### PR DESCRIPTION
bash has this weird way of converting numbers with leading zeros to octals, which means that the `todo` blocket will throw an error whenever _just_ a zero is passed into it. This works around it by using `awk` to `printf` the statement.

Also added tests to verify the script gives us proper output.