### PR TITLE
Added gawk specific testing for temp script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
   test:
     container: ubuntu:focal
     runs-on: ubuntu-latest
+    # We are running these tests for both awk variants
+    # See https://github.com/regolith-linux/regolith-i3xrocks-config/issues/107
+    strategy:
+      matrix:
+        awk: ["gawk", "mawk"]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare test environment
@@ -21,7 +26,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt update -qq
-          apt install --no-install-recommends -y curl ca-certificates iproute2 bc silversearcher-ag umockdev
+          apt install --no-install-recommends -y curl ca-certificates iproute2 bc silversearcher-ag umockdev ${{ matrix.awk }}
           cp tests/xrescat_mock /usr/bin/xrescat
           cp tests/i3-msg_mock /usr/bin/i3-msg
       - name: Run net-traffic test

--- a/scripts/temp
+++ b/scripts/temp
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+set -Eeu -o pipefail
+
 # Depends on lm-sensors (https://packages.ubuntu.com/bionic/lm-sensors)
 
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.thermometer )}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
-TEMP=$(sensors | awk -F '(\+|\.)' '/(Core|Tdie)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
+TEMP=$(sensors | awk -F '(\\+|\\.)' '/(Core|Tdie)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
 
 if [[ ${TEMP} -gt 90 ]]
 then

--- a/tests/fixtures/temp/third/sensors
+++ b/tests/fixtures/temp/third/sensors
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -Eeu -o pipefail
+
+echo "ucsi_source_psy_USBC000:001-isa-0000
+Adapter: ISA adapter
+in0:           5.00 V  (min =  +5.00 V, max =  +5.00 V)
+curr1:         0.00 A  (max =  +0.00 A)
+
+iwlwifi_1-virtual-0
+Adapter: Virtual device
+temp1:        +29.0°C
+
+pch_skylake-virtual-0
+Adapter: Virtual device
+temp1:        +38.0°C
+
+BAT0-acpi-0
+Adapter: ACPI interface
+in0:           8.40 V
+curr1:       805.00 mA
+
+coretemp-isa-0000
+Adapter: ISA adapter
+Package id 0:  +40.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 0:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 1:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 2:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 3:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
+
+dell_smm-virtual-0
+Adapter: Virtual device
+fan1:           0 RPM
+
+nvme-pci-3c00
+Adapter: PCI adapter
+Composite:    +28.9°C  (low  = -273.1°C, high = +80.8°C)
+                       (crit = +81.8°C)
+Sensor 1:     +28.9°C  (low  = -273.1°C, high = +65261.8°C)
+Sensor 2:     +30.9°C  (low  = -273.1°C, high = +65261.8°C)
+
+acpitz-acpi-0
+Adapter: ACPI interface
+temp1:        +25.0°C  (crit = +107.0°C)
+"

--- a/tests/temp_test.sh
+++ b/tests/temp_test.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "${SCRIPT_DIR}"
 
 declare -a FIXTURES
-FIXTURES=( "first" "second" )
+FIXTURES=( "first" "second" "third" )
 
 for fixture in "${FIXTURES[@]}"
 do


### PR DESCRIPTION
The default `awk` for `focal` is `nawk`, but for folks that want to install `gawk` instead (which overrides this default choice) we need to verify that the tests (and scripts therefore)  are working as well. The differences are subtle, but can "make or break" the experience for some users.

Fixes #107 