### PR TITLE
Filter VPN interfaces from net-traffic scripts

### DIFF
--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -15,7 +15,7 @@ RT=${RT:-}
 NUMFMT="numfmt --to iec --format %f --padding 5"
 
 # determine the net interface name
-IF="${BLOCK_INSTANCE:-$(ip route show default | awk 'NR==1 { print $5 }')}"
+IF="${BLOCK_INSTANCE:-$(ip route show default | awk '!/(ppp|tun|tap)/ { print $5 }')}"
 [ "$IF" = "" ] && exit
 
 IF_PATH="/sys/class/net/${IF}"

--- a/tests/fixtures/net-traffic/first/ip
+++ b/tests/fixtures/net-traffic/first/ip
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "default via 10.0.0.1 dev tun0 proto static metric 50
+default via 192.168.1.1 dev eth0 proto dhcp metric 600"

--- a/tests/fixtures/net-traffic/second/ip
+++ b/tests/fixtures/net-traffic/second/ip
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "default dev ppp0 proto static scope link metric 50 
+default via 192.168.0.1 dev eth0 proto dhcp metric 600"

--- a/tests/net-traffic_test.sh
+++ b/tests/net-traffic_test.sh
@@ -157,3 +157,29 @@ done
 sleep 5
 
 [ "1" -eq "$(ag -o '\>\s{2}2[.,]0K\<' /tmp/net-traffic-${BLOCK_INSTANCE}-output | wc -l)" ]
+
+# eth0, see whether we select the right interface, traffic is irrelevant
+# We shouldn't hard-code the device because it is supposed get this back from the ip mock
+unset BLOCK_INSTANCE
+BYTES="1024"
+
+for mock in "first" "second"; do
+    PATH="${PWD}/fixtures/net-traffic/${mock}:${PATH}"
+    export PATH
+
+    for b in rx tx; do
+        echo "${BYTES}" | bc >"${UMOCKDEV_DIR}/${SYS_PREFIX}/eth0/statistics/${b}_bytes"
+    done
+
+    ../scripts/net-traffic >"/tmp/net-traffic-eth0-output" &
+
+    sleep 1
+
+    for b in rx tx; do
+        echo "${BYTES}*6" | bc >"${UMOCKDEV_DIR}/${SYS_PREFIX}/eth0/statistics/${b}_bytes"
+    done
+
+    sleep 5
+
+    [ "2" -eq "$(ag -o '\>\s{2}1[.,]0K\<' /tmp/net-traffic-eth0-output | wc -l)" ]
+done


### PR DESCRIPTION
By default, VPN interfaces are showing up as default routes on the `main` table because they can be set as the default destination for traffic, while the actual, physical device (e.g. `eth0`) sits back as a sort of "shadow" default device (which is still necessary, otherwise you wouldn't be able to talk to your router/the Internet anymore). Unfortunately, this can cause the command `ip route show default` (which queries the  `main` table) to return multiple entries, including the VPN-bound default routes. Previously we tried to work around this by just cutting the output to a single line and taking whatever was returned. Unfortunately, that's not reliable enough (see the `ip` mocks I added for both, `tun0` and `ppp0` default routes) as the output slightly differs and makes parsing the results cumbersome.

I've decided to fix this by hard-filtering the output for any known VPN prefixes (`(ppp|tun|tap)`) which should then return only a single line, which is also the "true" default route. Traffic measurements should still work correctly, as any traffic passing through VPN tunnels is also aggregated into the device statistics of the relevant underlying network interface.

Fixes #109 

_PS: Yes, there can be multiple distinct default routes, but not in the same table and usually only on servers. We'll address that edge case once it hits us :wink:_