### PR TITLE
net-traffic cpu load w/ no or invalid network devices fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+regolith-i3xrocks-config (3.5.5-1ubuntu1) bionic; urgency=medium
+
+  [ Moritz Heiber ]
+  * Added gawk specific testing for temp script (#108)
+  * Filter all interfaces associated with VPN traffic while determining default route (#110)
+
+  [ Ken Gilmer ]
+  * Capture error cases involving invalid network device paths and sleep before returning to resolve CPU consuming loop due to  interval type of i3blocks.  Addresses https://github.com/regolith-linux/regolith-desktop/issues/532.
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 10 Jan 2021 11:25:46 -0800
+
 regolith-i3xrocks-config (3.5.4-1) bionic; urgency=medium
 
   [ Moritz Heiber ]

--- a/scripts/net-traffic
+++ b/scripts/net-traffic
@@ -2,6 +2,7 @@
 
 set -Eeu -o pipefail
 
+set -x
 # Note: net-traffic uses interval type 'repeat' so cannot use button events.
 # See https://github.com/vivien/i3blocks#interval
 
@@ -9,6 +10,7 @@ set -Eeu -o pipefail
 UP=${label_icon:-$(xrescat i3xrocks.label.up " up")}
 DN=${label_icon:-$(xrescat i3xrocks.label.dn " dn")}
 DLY=${DLY:-5}
+ERROR_DLY=${ERROR_DLY:-10}
 RT=${RT:-}
 
 # Padding the output to 5 characters to avoid jittering on the bar
@@ -16,9 +18,13 @@ NUMFMT="numfmt --to iec --format %f --padding 5"
 
 # determine the net interface name
 IF="${BLOCK_INSTANCE:-$(ip route show default | awk '!/(ppp|tun|tap)/ { print $5 }')}"
-[ "$IF" = "" ] && exit
 
 IF_PATH="/sys/class/net/${IF}"
+
+if [[ "$IF" == "" || ! -d "$IF_PATH" || ! -f "${IF_PATH}"/statistics/rx_bytes || ! -f "${IF_PATH}"/statistics/tx_bytes ]]; then 
+  sleep "${ERROR_DLY}"
+  exit 1
+fi
 
 if [ -d "${IF_PATH}/wireless" ]; then
   NIC=${label_icon:-$(xrescat i3xrocks.label.wifi )}


### PR DESCRIPTION
Capture error cases involving invalid network device paths and sleep before returning to resolve CPU consuming loop due to  interval type of i3blocks.  Addresses https://github.com/regolith-linux/regolith-desktop/issues/532.

## Testing Done

1. On local machine, observe issue when disabling wifi.  
2. Replace `release` version of `net-traffic` script with this
3. disable and renable wifi
4. observe no obvious increase load on machine based on network connectivity state
