### PR TITLE
Remove extra space in nm-vpn output

### DIFF
--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -17,6 +17,6 @@ VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 if [[ -z "$CONNECTION" ]]; then
     exit 0
 else
-    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\"> </span> <span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
+    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
     echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\"> </span>" # short text
 fi


### PR DESCRIPTION
There are currently two space characters between the icon and the name of the VPN connection.

All other scripts only have a single space. This removes the extra space to make it consistent with the other scripts.