### PR TITLE
Modified the temp script to recognize temp for Ryzen 4300U / Thinkpad E14g2 output

### DIFF
--- a/scripts/temp
+++ b/scripts/temp
@@ -7,7 +7,7 @@ set -Eeu -o pipefail
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.thermometer )}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
-TEMP=$(sensors | awk -F '(\\+|\\.)' '/(Core|Tdie|Tctl)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
+TEMP=$(sensors | awk -F '(\\+|\\.)' '/(Core|Tdie|Tctl|CPU)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
 
 if [[ ${TEMP} -gt 90 ]]; then
   COLOR=${critical_color:-$(xrescat i3xrocks.critical.color "#BF616A")}

--- a/scripts/temp
+++ b/scripts/temp
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -Eeu -o pipefail
+
+# Debug: echo all called commands
 set -x
 
 # Depends on lm-sensors (https://packages.ubuntu.com/bionic/lm-sensors)
@@ -16,14 +18,14 @@ COMMAND_Tdie=( awk -F '(\\+|\\.)' '/(Tdie)/ {printf $2}' )
 # "Core #" is prioritized, then "Tctl", then "Tdie", then "CPU"
 # Change this if-elif to reorder priority
 sensors_output=$(sensors)
-if echo $sensors_output | grep -q "Core"; then
-  TEMP=$(echo $sensors_output | "${COMMAND_CPU[@]}")
-elif echo $sensors_output | grep -q "Tctl"; then
-  TEMP=$(echo $sensors_output | "${COMMAND_Tctl[@]}")
-elif echo $sensors_output | grep -q "Tdie"; then
-  TEMP=$(echo $sensors_output | "${COMMAND_Tdie[@]}")
-elif echo $sensors_output | grep -q "Core"; then
-  TEMP=$(echo $sensors_output | "${COMMAND_Core[@]}")
+if echo "$sensors_output" | grep -q "Core"; then
+  TEMP=$(echo "$sensors_output" | "${COMMAND_Core[@]}")
+elif echo "$sensors_output" | grep -q "Tctl"; then
+  TEMP=$(echo "$sensors_output" | "${COMMAND_Tctl[@]}")
+elif echo "$sensors_output" | grep -q "Tdie"; then
+  TEMP=$(echo "$sensors_output" | "${COMMAND_Tdie[@]}")
+elif echo "$sensors_output" | grep -q "CPU"; then
+  TEMP=$(echo "$sensors_output" | "${COMMAND_CPU[@]}")
 else
   TEMP="err"
 fi

--- a/scripts/temp
+++ b/scripts/temp
@@ -1,13 +1,32 @@
 #!/bin/bash
 
 set -Eeu -o pipefail
+set -x
 
 # Depends on lm-sensors (https://packages.ubuntu.com/bionic/lm-sensors)
 
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro Medium 13")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.thermometer )}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
-TEMP=$(sensors | awk -F '(\\+|\\.)' '/(Core|Tdie|Tctl|CPU)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
+COMMAND_CPU=( awk -F '(\\+|\\.)' '/(CPU)/ {printf $2}' )
+COMMAND_Tctl=( awk -F '(\\+|\\.)' '/(Tctl)/ {printf $2}' )
+COMMAND_Core=( awk -F '(\\+|\\.)' '/(Core)/ {sum+= $2; count++} END { printf "%d\n", sum/count}')
+COMMAND_Tdie=( awk -F '(\\+|\\.)' '/(Tdie)/ {printf $2}' )
+
+# "Core #" is prioritized, then "Tctl", then "Tdie", then "CPU"
+# Change this if-elif to reorder priority
+sensors_output=$(sensors)
+if echo $sensors_output | grep -q "Core"; then
+  TEMP=$(echo $sensors_output | "${COMMAND_CPU[@]}")
+elif echo $sensors_output | grep -q "Tctl"; then
+  TEMP=$(echo $sensors_output | "${COMMAND_Tctl[@]}")
+elif echo $sensors_output | grep -q "Tdie"; then
+  TEMP=$(echo $sensors_output | "${COMMAND_Tdie[@]}")
+elif echo $sensors_output | grep -q "Core"; then
+  TEMP=$(echo $sensors_output | "${COMMAND_Core[@]}")
+else
+  TEMP="err"
+fi
 
 if [[ ${TEMP} -gt 90 ]]; then
   COLOR=${critical_color:-$(xrescat i3xrocks.critical.color "#BF616A")}

--- a/scripts/temp
+++ b/scripts/temp
@@ -3,7 +3,7 @@
 set -Eeu -o pipefail
 
 # Debug: echo all called commands
-set -x
+# set -x
 
 # Depends on lm-sensors (https://packages.ubuntu.com/bionic/lm-sensors)
 


### PR DESCRIPTION
Original script returned -2147483648 (probably as a result of 0/0 from awk trying to average over non-existent values) (had an older version of the script, without the Tctl).
My `sensors` output:
```
╰─$ sensors
thinkpad-isa-0000
Adapter: ISA adapter
fan1:           0 RPM
fan2:           0 RPM
CPU:          +35.0°C  
GPU:           +0.0°C  
temp3:         +0.0°C  
temp4:         +0.0°C  
temp5:         +0.0°C  
temp6:         +0.0°C  
temp7:         +0.0°C  
temp8:         +0.0°C  

k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +35.5°C  

nvme-pci-0100
Adapter: PCI adapter
Composite:    +32.9°C  (low  =  -5.2°C, high = +79.8°C)
                       (crit = +84.8°C)

iwlwifi_1-virtual-0
Adapter: Virtual device
temp1:        +33.0°C  

amdgpu-pci-0400
Adapter: PCI adapter
vddgfx:      806.00 mV 
vddnb:       774.00 mV 
edge:         +35.0°C  
slowPPT:     1000.00 uW 

BAT0-acpi-0
Adapter: ACPI interface
in0:          11.93 V
```

Don't know if this is a thinkpad-related issue, a ryzen 4000 - related issue, or something else, but seems like this output format is also possible.

Possibility is, that a "CPU"-only output format could exist, if one would not have k10temp loaded.

Possible problem in this PR is that it now averages over "CPU", "Tctl", and core temperatures, if any. The awk command probably needs to differentiate between these cases.