### PR TITLE
Fixed volume and microphone mixer_value to display values below 10 and prepend a zero if value is below 10

### DIFF
--- a/scripts/microphone
+++ b/scripts/microphone
@@ -63,10 +63,13 @@ mixer_status() {
 }
 
 mixer_value() {
-    VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
+    VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
     if [ -z "$VAL" ]; then
         # return empty string of same width to prevent bar shift.
         echo "   "
+    elif [ "$VAL" -lt "10" ]; then
+        # prepend a zero if volume is below 10
+        echo "0$VAL$UNIT"
     else
         echo "$VAL$UNIT"
     fi

--- a/scripts/volume
+++ b/scripts/volume
@@ -63,10 +63,13 @@ mixer_status() {
 }
 
 mixer_value() {
-    VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+.?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
+    VAL=$(mixer_info | sed -n -E "s/.*\[(-?[0-9]+)$UNIT\].*/\1/p" | head -n 1)
     if [ -z "$VAL" ]; then
         # return empty string of same width to prevent bar shift.
         echo "   "
+    elif [ "$VAL" -lt "10" ]; then
+        # prepend a zero if volume is below 10
+        echo "0$VAL$UNIT"
     else
         echo "$VAL$UNIT"
     fi


### PR DESCRIPTION
## Description
This PR fixes #135, which describes the issue that if the volume or microphone level is below 10 no value is displayed in the status bar.

## Changes
Altered the `sed`-regex within the `mixer_value` function to also include single-digit values and extended the if-logic to prepend a zero if the value s below 10 to avoid bar shift / jumping output in the volume and microphone script.

## Test
Successfully tested both scripts in a virtual machine (Ubuntu server 22.04 LTS with regolith set up like it's described here: [https://regolith-desktop.com/docs/howtos/minimal-ubuntu-install/](https://regolith-desktop.com/docs/howtos/minimal-ubuntu-install/)).