### PR TITLE
Try to use bluetooth device alias instead of name

### DIFF
--- a/scripts/bluetooth
+++ b/scripts/bluetooth
@@ -54,6 +54,9 @@ class Bluetooth(object):
                             if "Name" not in dev:
                                 dev["Name"] = "<unknown>"
 
+                            if "Alias" in dev:
+                                dev["Name"] = dev["Alias"]
+
                             device = {
                                 "mac_address": dev["Address"].encode("utf-8"),
                                 "name": dev["Name"].encode("utf-8")


### PR DESCRIPTION
When an alias for a bluetooth device has been set (for example, with `bluetoothctl set-alias ...`), we can use it instead of the device's full name.

There are no tests for the bluetooth script yet.
This is a very small touch, so no tests have been added here either.
