### PR TITLE
Use a … instead of ... to show more of the artist and title

### DIFF
--- a/scripts/media-player
+++ b/scripts/media-player
@@ -31,14 +31,14 @@ TITLE="$(playerctl $PLAYER_ARGS metadata title)"
 # get half of the total allowed field width
 HALF_FIELD_WIDTH=$(( FIELD_WIDTH / 2 ))
 
-# trim artist length, remove an extra 4 to allow for spaces and "..."
+# trim artist length, remove an extra 2 to allow for spaces and "…"
 if [[ ${#ARTIST} -gt ${HALF_FIELD_WIDTH} ]]; then
-    ARTIST="${ARTIST:0:$(( HALF_FIELD_WIDTH -4 ))}..."
+    ARTIST="${ARTIST:0:$(( HALF_FIELD_WIDTH -2 ))}…"
 fi
 
-# trim song title length, remove an extra 5 to allow for the separator and "..."
+# trim song title length, remove an extra 3 to allow for the separator and "…"
 if [[ ${#TITLE} -gt ${HALF_FIELD_WIDTH} ]]; then
-    TITLE="${TITLE:0:$(( HALF_FIELD_WIDTH -5 ))}..."
+    TITLE="${TITLE:0:$(( HALF_FIELD_WIDTH -3 ))}…"
 fi
 
 # print resulting information (fulltext)


### PR DESCRIPTION
When we truncate the media-player's artist and track title it would be nice to show as much of it as possible.

Previously we chop 4 and 5 characters off of the artist and track respectively for the spacing and ellipsis as `...`.
This PR simply uses the unicode ellipsis character `…` U+2026 so we only have to chop 2 and 3 characters off!