### PR TITLE
fix(keyboard-layout): open keyboard menu instead

### DIFF
--- a/scripts/keyboard-layout
+++ b/scripts/keyboard-layout
@@ -25,8 +25,8 @@ echo "${PANGO_START}${KBD}${PANGO_END}"
 
 case "x${BUTTON}" in
 "x1")
-    # Handle left click, default to launch region settings
-    LEFT_CLICK_ACTION=$(xrescat i3xrocks.keyboard_layout.left_click_action "regolith-control-center region")
+    # Handle left click, default to launch keyboard settings
+    LEFT_CLICK_ACTION=$(xrescat i3xrocks.keyboard_layout.left_click_action "regolith-control-center keyboard")
     [[ ! -z $LEFT_CLICK_ACTION ]] && $(which i3-msg) -q exec "$LEFT_CLICK_ACTION"
     ;;
 "x2")


### PR DESCRIPTION
Hi :wave:,

I installed Regolith Linux 2.2 from the ISO [here](https://regolith-desktop.com/#get-regolith-22) today. After inspecting the `i3xrocks-keyboard-layout` package, I found that the left click action links to the wrong gnome settings menu:

![before](https://user-images.githubusercontent.com/5375334/208548967-4a2810cc-6731-4c87-a1e9-751530bd4c5c.png)

From my understanding it makes more sense to link to the keyboard layout settings here:

![after](https://user-images.githubusercontent.com/5375334/208549030-78606a6f-ac00-4c85-b7e3-7eef49991a08.png)

I assume the menu setting entries were changed upstream. Correct me if I am wrong. Let me know if you want anything changed.
 