### PR TITLE
Use value colors for battery percentage and charge

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -42,10 +42,10 @@ elif [ "$BATT_PERCENT" -ge 50 ] && [ "$BATT_PERCENT" -le 80 ]; then
     VALUE_COLOR=$(xrescat i3xrocks.nominal white)
 elif [ "$BATT_PERCENT" -ge 80 ] && [ "$BATT_PERCENT" -le 98 ]; then
     LABEL_ICON=$(xrescat i3xrocks.label.battery80 F)
-    VALUE_COLOR=$(xrescat i3xrocks.label.color white)
+    VALUE_COLOR=$(xrescat i3xrocks.value.color white)
 else
     LABEL_ICON=$(xrescat i3xrocks.label.battery100 C)
-    VALUE_COLOR=$(xrescat i3xrocks.label.color white)
+    VALUE_COLOR=$(xrescat i3xrocks.value.color white)
 fi
 
 if [ -z "$CHARGE_STATE" ]; then
@@ -60,7 +60,7 @@ fi
 
 ICON_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
 VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $BATT_PERCENT%</span>"
-CHARGE_SPAN="<span color=\"${LABEL_COLOR}\">$CHARGE_ICON</span>"
+CHARGE_SPAN="<span color=\"${VALUE_COLOR}\">$CHARGE_ICON</span>"
 
 echo "${ICON_SPAN}${VALUE_SPAN}${CHARGE_SPAN}"
 


### PR DESCRIPTION
I think this fixes a layout error. All i3xrocks indicator values are shown with `xrescat i3xrocks.value.color` except for battery. The battery script uses `xrescat i3xrocks.label.color`. This change fixes it. 

I've made this change for my own setup and think maybe others will like it too. 