### PR TITLE
Properly use colors for rofication message count

### DIFF
--- a/scripts/rofication
+++ b/scripts/rofication
@@ -35,15 +35,15 @@ get_info() {
 get_info
 
 if [ $CRIT_NOTIFICATION_COUNT -gt 0 ]; then 
-    VALUE_COLOR=${color:-$(xrescat i3xrocks.critical.color "#D8DEE9")}
+    VALUE_COLOR=$(xrescat i3xrocks.critical.color "#D8DEE9")
     LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.notify.some N)}
     NOTIFICATION_LABEL="$CRIT_NOTIFICATION_COUNT/$NOTIFICATION_COUNT"
 elif [ $NOTIFICATION_COUNT -gt 0 ]; then
-    VALUE_COLOR=${color:-$(xrescat i3xrocks.warning "#D8DEE9")}
+    VALUE_COLOR=$(xrescat i3xrocks.warning "#D8DEE9")
     LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.notify.some N)}
     NOTIFICATION_LABEL="$NOTIFICATION_COUNT"
 else
-    VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
+    VALUE_COLOR=$(xrescat i3xrocks.value.color "#D8DEE9")
     LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.notify.none N)}
     NOTIFICATION_LABEL="0"
 fi


### PR DESCRIPTION
Unlike the `battery` script, this script uses `{$color:-}` ahead of the xrescat call. As `color` is always provided, it takes precedence and the warning and critical colors are never used. This change ignores $color and just uses the result from the respective xrescat calls.
    
Arguably the fallback values should not be `#D8DEE9` for all, but I expect the referenced resources to be there at all times.
