### PR TITLE
nm-vpn script: awk-free + refactoring

### DIFF
--- a/scripts/nm-vpn
+++ b/scripts/nm-vpn
@@ -1,24 +1,25 @@
 #!/bin/bash
 
-CONNECTION=$(LC_ALL=C nmcli -t connection show --active | awk -F ':' '
-{ if($3 == "vpn") {
-    vpn_name=$1
-  } else if ($3 == "tun"){
-    tun_name=$1
-  } else if ($3 == "tap"){
-    tun_name=$1
-  } else if ($3 == "wireguard"){
-    tun_name=$1
-  }
-}
-END{if (vpn_name) {printf("%s", vpn_name)}  else if(tun_name) {printf("%s", tun_name)}}')
+SECURE_CONNECTIONS=("vpn" "tun" "tap" "wireguard" "openvpn" "openconnect" "wireguard-vpn")
+ICON=""
+
+# Find first secure connection
+CONNECTION=""
+while IFS=: read -r NAME TYPE; do
+    for SECURE in "${SECURE_CONNECTIONS[@]}"; do
+        if [[ "$TYPE" == "$SECURE" ]]; then 
+          CONNECTION=$NAME 
+          break 2
+        fi
+    done
+done < <(LC_ALL=C.utf8 nmcli -t -f NAME,TYPE connection show --active)
+
+# OUTPUT
 LABEL_COLOR=${vpn_label_color:-$(xrescat i3xrocks.label.color)}
 VALUE_COLOR="${vpn_color:-$(xrescat i3xrocks.value.color)}"
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font)}
 
-if [[ -z "$CONNECTION" ]]; then
-    exit 0
-else
-    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\"> </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
-    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\"> </span>" # short text
+if [[ -n "$CONNECTION" ]]; then
+    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\">${ICON} </span><span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$CONNECTION</span>" # full text
+    echo "<span color=\"${LABEL_COLOR}\" font_desc=\"${VALUE_FONT}\">${ICON} </span>" # short text
 fi


### PR DESCRIPTION
Slightly more readable and easy-to-maintain version

- Expanded list of possibe connection names
- Dropped piping to awk (pure bash - less resources)