### PR TITLE
fix: align ilia launch commands with wm config

### DIFF
--- a/conf.d/20_app-launcher
+++ b/conf.d/20_app-launcher
@@ -2,4 +2,3 @@
 #
 [app-launcher]
 full_text=xresource:i3xrocks.label.app_launcher
-command=i3-msg -q "exec --no-startup-id ilia -a -p apps"

--- a/conf.d/20_info
+++ b/conf.d/20_info
@@ -1,4 +1,3 @@
 # Link to execute shortcuts.
 [info]
 full_text=xresource:i3xrocks.label.help
-command=i3-msg -q "exec --no-startup-id ilia -p keybindings"

--- a/debian/i3xrocks-app-launcher.install
+++ b/debian/i3xrocks-app-launcher.install
@@ -1,1 +1,2 @@
+scripts/app-launcher /usr/share/i3xrocks/scripts
 conf.d/20_app-launcher /usr/share/i3xrocks/conf.d

--- a/debian/i3xrocks-info.install
+++ b/debian/i3xrocks-info.install
@@ -1,1 +1,2 @@
+scripts/info /usr/share/i3xrocks/scripts
 conf.d/20_info /usr/share/i3xrocks/conf.d

--- a/scripts/app-launcher
+++ b/scripts/app-launcher
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ILIA_STYLESHEET=${ilia_stylesheet:-$(xrescat ilia.stylesheet "/usr/share/regolith-look/default/ilia.css")}
+BUTTON=${button:-}
+
+if [ -f "$ILIA_STYLESHEET" ]; then
+    ACTION="ilia -p apps -t \"$ILIA_STYLESHEET\""
+else
+    ACTION="ilia -p apps"
+fi
+
+if [ "x${BUTTON}" == "x1" ]; then
+    /usr/bin/i3-msg -q "exec --no-startup-id $ACTION"
+fi

--- a/scripts/info
+++ b/scripts/info
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ILIA_STYLESHEET=${ilia_stylesheet:-$(xrescat ilia.stylesheet "/usr/share/regolith-look/default/ilia.css")}
+BUTTON=${button:-}
+
+if [ -f "$ILIA_STYLESHEET" ]; then
+    ACTION="ilia -a -p keybindings -t \"$ILIA_STYLESHEET\""
+else
+    ACTION="ilia -a -p keybindings"
+fi
+
+if [ "x${BUTTON}" == "x1" ]; then
+    /usr/bin/i3-msg -q "exec --no-startup-id $ACTION"
+fi


### PR DESCRIPTION
This PR makes the ilia launch commands match the i3/sway wm configs ([i3](https://github.com/regolith-linux/regolith-wm-config/blob/main/usr/share/regolith/i3/config.d/20_ilia#L4), [sway](https://github.com/regolith-linux/regolith-wm-config/blob/main/usr/share/regolith/sway/config.d/20_ilia)).

- Use scripts that read `ilia.stylesheet` from Xresources and pass `-t` when the stylesheet file exists, otherwise let ilia fall back to its default style (from `default_css` in [Application.vala](https://github.com/regolith-linux/ilia/blob/main/src/Application.vala#L4)).
- Run `ilia -p apps` for the app launcher and `ilia -a -p keybindings` for the keybindings viewer, consistent with the wm configs.